### PR TITLE
raise the error if no sales person

### DIFF
--- a/app/tc2/_process.py
+++ b/app/tc2/_process.py
@@ -20,7 +20,7 @@ async def _create_or_update_company(tc2_client: TCClient) -> tuple[bool, Company
     company_data = tc2_client.company_dict(company_custom_fields)
     company_id = company_data.pop('tc2_agency_id')
 
-    if company_data['sales_person'] == None:
+    if company_data['sales_person'] is None:
         raise ValidationError('Company must have a sales_person, Please add one in TC2')
 
     company, created = await Company.get_or_create(tc2_agency_id=company_id, defaults=company_data)

--- a/app/tc2/_process.py
+++ b/app/tc2/_process.py
@@ -19,6 +19,10 @@ async def _create_or_update_company(tc2_client: TCClient) -> tuple[bool, Company
     company_custom_fields = await CustomField.filter(linked_object_type='Company')
     company_data = tc2_client.company_dict(company_custom_fields)
     company_id = company_data.pop('tc2_agency_id')
+
+    if company_data['sales_person'] == None:
+        raise ValidationError('Company must have a sales_person, Please add one in TC2')
+
     company, created = await Company.get_or_create(tc2_agency_id=company_id, defaults=company_data)
     if not created:
         company = await company.update_from_dict(company_data)

--- a/tests/test_tc2.py
+++ b/tests/test_tc2.py
@@ -6,7 +6,6 @@ import re
 from datetime import datetime, timedelta
 from unittest import mock
 
-from pydantic_core._pydantic_core import ValidationError
 from requests import HTTPError
 
 from app.base_schema import build_custom_field_schema
@@ -451,13 +450,10 @@ class TC2CallbackTestCase(HermesTestCase):
     @mock.patch('fastapi.BackgroundTasks.add_task')
     async def test_create_company_no_sales_person(self, mock_add_task):
         """
-        Create a new company
-        Dont create contacts
-        Dont create deal
-        With associated admin
+        Company with no sales person, to raise clear Error
         """
 
-        admin = await Admin.create(
+        await Admin.create(
             tc2_admin_id=30, first_name='Brain', last_name='Johnson', username='brian@tc.com', password='foo'
         )
 
@@ -471,7 +467,6 @@ class TC2CallbackTestCase(HermesTestCase):
         data = {'_request_time': 123, 'events': events}
         with self.assertRaises(TypeError):
             await self.client.post(self.url, json=data, headers={'Webhook-Signature': self._tc2_sig(data)})
-
 
     async def test_cb_client_deleted_no_linked_data(self):
         """

--- a/tests/test_tc2.py
+++ b/tests/test_tc2.py
@@ -6,6 +6,7 @@ import re
 from datetime import datetime, timedelta
 from unittest import mock
 
+from pydantic_core._pydantic_core import ValidationError
 from requests import HTTPError
 
 from app.base_schema import build_custom_field_schema
@@ -446,6 +447,31 @@ class TC2CallbackTestCase(HermesTestCase):
 
         assert await Contact.all().count() == 1
         assert await Deal.all().count() == 0
+
+    @mock.patch('fastapi.BackgroundTasks.add_task')
+    async def test_create_company_no_sales_person(self, mock_add_task):
+        """
+        Create a new company
+        Dont create contacts
+        Dont create deal
+        With associated admin
+        """
+
+        admin = await Admin.create(
+            tc2_admin_id=30, first_name='Brain', last_name='Johnson', username='brian@tc.com', password='foo'
+        )
+
+        assert await Company.all().count() == 0
+        assert await Contact.all().count() == 0
+        assert await Deal.all().count() == 0
+        modified_data = client_full_event_data()
+        modified_data['subject']['sales_person'] = None
+        events = [modified_data]
+
+        data = {'_request_time': 123, 'events': events}
+        with self.assertRaises(TypeError):
+            await self.client.post(self.url, json=data, headers={'Webhook-Signature': self._tc2_sig(data)})
+
 
     async def test_cb_client_deleted_no_linked_data(self):
         """


### PR DESCRIPTION
Fix #108 

On occasion we would get a client with no sales person, this now raises a better error to let me know to edit the meta client so that it has a sales person