### PR TITLE
make TCUser email optional

### DIFF
--- a/app/tc2/_schema.py
+++ b/app/tc2/_schema.py
@@ -69,7 +69,7 @@ class TCRecipient(_TCSimpleRole):
 
 
 class TCUser(HermesBaseModel):
-    email: str
+    email: Optional[str] = None
     phone: Optional[str] = None
     first_name: Optional[str] = None
     last_name: str

--- a/tests/test_tc2.py
+++ b/tests/test_tc2.py
@@ -448,6 +448,42 @@ class TC2CallbackTestCase(HermesTestCase):
         assert await Deal.all().count() == 0
 
     @mock.patch('fastapi.BackgroundTasks.add_task')
+    async def test_create_company_no_user_email(self, mock_add_task):
+        """
+        Create a new company with no user email
+        Dont create contacts
+        Dont create deal
+        With associated admin
+        """
+
+        admin = await Admin.create(
+            tc2_admin_id=30, first_name='Brain', last_name='Johnson', username='brian@tc.com', password='foo'
+        )
+
+        assert await Company.all().count() == 0
+        assert await Contact.all().count() == 0
+        assert await Deal.all().count() == 0
+        modified_data = client_full_event_data()
+        modified_data['subject']['user'].pop('email')
+        events = [modified_data]
+
+        data = {'_request_time': 123, 'events': events}
+        r = await self.client.post(self.url, json=data, headers={'Webhook-Signature': self._tc2_sig(data)})
+        assert r.status_code == 200, r.json()
+
+        company = await Company.get()
+        assert company.name == 'MyTutors'
+        assert company.tc2_agency_id == 20
+        assert company.tc2_cligency_id == 10
+        assert company.tc2_status == 'active'
+        assert company.country == 'GB'
+        assert company.paid_invoice_count == 2
+        assert await company.support_person == await company.sales_person == admin
+
+        assert await Contact.all().count() == 1
+        assert await Deal.all().count() == 0
+
+    @mock.patch('fastapi.BackgroundTasks.add_task')
     async def test_create_company_no_sales_person(self, mock_add_task):
         """
         Company with no sales person, to raise clear Error


### PR DESCRIPTION
Fix #124


## Description

Sometimes a Client from TC has no user email, this was causing a validation error.

As a result we now have email as an optional field on the `TCUser`﻿
