### PR TITLE
change ignore actions to ignore if the event subject has no meta_agency

### DIFF
--- a/app/tc2/views.py
+++ b/app/tc2/views.py
@@ -29,7 +29,6 @@ async def callback(
     if not webhook_signature or not compare_digest(webhook_signature, expected_sig):
         raise HTTPException(status_code=403, detail='Unauthorized key')
     for event in webhook.events:
-        debug(event.action)
         company, deal = None, None
         if event.subject.model == 'Client':
             if not event.action == 'DELETED_A_CLIENT' and not hasattr(event.subject, 'meta_agency'):

--- a/app/tc2/views.py
+++ b/app/tc2/views.py
@@ -29,10 +29,11 @@ async def callback(
     if not webhook_signature or not compare_digest(webhook_signature, expected_sig):
         raise HTTPException(status_code=403, detail='Unauthorized key')
     for event in webhook.events:
-        if not hasattr(event.subject, 'meta_agency'):
-            continue
+        debug(event.action)
         company, deal = None, None
         if event.subject.model == 'Client':
+            if not event.action == 'DELETED_A_CLIENT' and not hasattr(event.subject, 'meta_agency'):
+                continue
             company, deal = await update_from_client_event(event.subject)
         elif event.subject.model == 'Invoice':
             company, deal = await update_from_invoice_event(event.subject)

--- a/app/tc2/views.py
+++ b/app/tc2/views.py
@@ -15,8 +15,6 @@ from app.utils import settings
 
 tc2_router = APIRouter()
 
-IGNORED_ACTIONS = ['AGREE_TERMS', 'CLIENT_ENQUIRY']
-
 
 @tc2_router.post('/callback/', name='TC2 callback')
 async def callback(
@@ -25,12 +23,13 @@ async def callback(
     """
     Callback for TC2
     Updates Hermes and other systems based on events in TC2.
+    Ignores events that don't have a meta_agency.
     """
     expected_sig = hmac.new(settings.tc2_api_key.encode(), (await request.body()), hashlib.sha256).hexdigest()
     if not webhook_signature or not compare_digest(webhook_signature, expected_sig):
         raise HTTPException(status_code=403, detail='Unauthorized key')
     for event in webhook.events:
-        if event.action in IGNORED_ACTIONS:
+        if not hasattr(event.subject, 'meta_agency'):
             continue
         company, deal = None, None
         if event.subject.model == 'Client':

--- a/tests/test_tc2.py
+++ b/tests/test_tc2.py
@@ -147,9 +147,9 @@ class TC2CallbackTestCase(HermesTestCase):
         r = await self.client.post(self.url, json=data, headers={'Webhook-Signature': self._tc2_sig(data)})
         assert r.status_code == 422, r.json()
 
-    async def test_ingnored_actions(self):
+    async def test_ingnored_actions_no_meta_agency(self):
         """
-        try to create a company with an ignored action
+        try to create a company with no meta_agency
         """
         assert await Company.all().count() == 0
         assert await Contact.all().count() == 0

--- a/tests/test_tc2.py
+++ b/tests/test_tc2.py
@@ -74,7 +74,7 @@ def client_full_event_data():
 
 def client_deleted_event_data():
     return {
-        'action': 'delete',
+        'action': 'DELETED_A_CLIENT',
         'verb': 'delete',
         'subject': {
             'id': 10,


### PR DESCRIPTION
Continue from #146

Changed from having a list of action names to ignore

to ignore all events that `event.subject` has no `meta_agency`﻿ this way we will be able to better cover other use cases such as when we have ad hoc charges to Clients such as Pydantic of Burren Balsamics
