### PR TITLE
Fix BDR

### DIFF
--- a/app/callbooker/_schema.py
+++ b/app/callbooker/_schema.py
@@ -32,7 +32,7 @@ def _to_title(v: str) -> str:
 
 class CBSalesCall(HermesBaseModel):
     admin_id: int = ForeignKeyField(model=Admin)
-    bdr_person_id: Optional[int] = ForeignKeyField(None, model=Admin, to_field='bdr')
+    bdr_person_id: Optional[int] = None # changed this as the value we now receive is the tc2 admin id
     utm_campaign: Optional[str] = None
     utm_source: Optional[str] = None
     company_id: Optional[int] = ForeignKeyField(None, model=Company)
@@ -74,7 +74,7 @@ class CBSalesCall(HermesBaseModel):
     async def company_dict(self) -> dict:
         return {
             'sales_person_id': (await self.admin).id,
-            'bdr_person_id': (await self.bdr).id if self.bdr else None,
+            'bdr_person_id': self.bdr_person_id,
             'utm_campaign': self.utm_campaign,
             'utm_source': self.utm_source,
             'estimated_income': self.estimated_income,

--- a/app/callbooker/views.py
+++ b/app/callbooker/views.py
@@ -32,6 +32,7 @@ async def sales_call(event: CBSalesCall, tasks: BackgroundTasks):
     """
     await event.a_validate()
     company, contact = await get_or_create_contact_company(event)
+    debug(company.__dict__)
     deal = await get_or_create_deal(company, contact)
     try:
         meeting = await book_meeting(company=company, contact=contact, event=event)

--- a/tests/test_callbooker.py
+++ b/tests/test_callbooker.py
@@ -409,6 +409,71 @@ class MeetingBookingTestCase(HermesTestCase):
         assert await meeting.contact == contact
         assert meeting.meeting_type == Meeting.TYPE_SALES
 
+    @mock.patch('fastapi.BackgroundTasks.add_task')
+    @mock.patch('app.callbooker._google.AdminGoogleCalendar._create_resource')
+    async def test_com_cli_create_update_7_bdr(self, mock_gcal_builder, mock_add_task):
+        """
+        Book a new meeting
+        Company doesn't exist so create
+        Contact doesn't exist so create
+        Create with admin
+        """
+        mock_gcal_builder.side_effect = fake_gcal_builder()
+        sales_person = await Admin.create(
+            first_name='Steve', last_name='Jobs', username='climan@example.com', is_support_person=True
+        )
+
+        bdr_person = await Admin.create(first_name='Steve', last_name='Woz', username='steve.woz@example.com', tc2_admin_id=2543678, is_bdr_person=True)
+
+        assert await Company.all().count() == 0
+        assert await Contact.all().count() == 0
+
+        meeting_data = {
+            'bdr_person_id': '2543678',
+            'company_name': 'MegaReee Ltd',
+            'country': 'GB',
+            'currency': 'GBP',
+            'estimated_income': 'Just Starting Out',
+            'phone': '0123456789',
+            'price_plan': 'payg',
+            'utm_campaign': 'utm_campaign_1',
+            'utm_source': 'utm_source_1',
+            'website': 'https://megareee.com',
+
+            'meeting_dt': int(datetime(2026, 7, 3, 9, tzinfo=utc).timestamp()),
+            'email': 'michael.reeeves@reemail.com',
+            'name': 'Michael Reeeeves',
+
+        }
+
+        r = await self.client.post(self.url,
+                                   json={'admin_id': sales_person.id, 'bdr_person_id': bdr_person.tc2_admin_id, **meeting_data})
+        debug(r.json())
+        assert r.status_code == 200, r.json()
+
+        company = await Company.get()
+        assert not company.tc2_cligency_id
+        assert company.name == 'MegaReee Ltd'
+        assert company.website == 'https://megareee.com'
+        assert company.country == 'GB'
+        assert company.estimated_income == 'Just Starting Out'
+        assert not company.support_person_id
+        assert company.bdr_person_id == bdr_person.id
+        assert await company.sales_person == sales_person
+
+        contact = await Contact.get()
+        assert contact.first_name == 'Michael'
+        assert contact.last_name == 'Reeeeves'
+        assert contact.email == 'michael.reeeves@reemail.com'
+        assert contact.company_id == company.id
+
+        meeting = await Meeting.get()
+        assert meeting.status == Meeting.STATUS_PLANNED
+        assert meeting.start_time == datetime(2026, 7, 3, 9, tzinfo=utc)
+        assert await meeting.admin == sales_person
+        assert await meeting.contact == contact
+        assert meeting.meeting_type == Meeting.TYPE_SALES
+
     async def test_meeting_already_exists(self):
         sales_person = await Admin.create(
             first_name='Steve', last_name='Jobs', username='climan@example.com', is_support_person=True


### PR DESCRIPTION
in the event:
`bdr_person_id`﻿ == the TC BDR Administrator.id

In Hermes:

We have Company.bdr_person, which is a Foegin Key to Admin


Issue: Before there was a bug where we were trying to get the Admin id by the TC Administrator.id


Fix:

Now we Get the `Admin.get(tc2_admin_id=company_data['bdr_person_id']` which returns the Hermes BDR admin correctly
