### PR TITLE
Fix 422 errors occurring on Pipedrive Callback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,8 @@ install-dev:
 	pip install -r requirements.txt
 	pip install -r tests/requirements.txt
 	pip install devtools
+
+.PHONY: restore-from-live
+restore-from-live:
+	heroku pg:backups:download --app tc-hermes
+	make reset-db && time pg_restore --clean --no-acl --no-owner -j12 -h localhost -U postgres -d hermes latest.dump

--- a/Makefile
+++ b/Makefile
@@ -30,5 +30,6 @@ install-dev:
 
 .PHONY: restore-from-live
 restore-from-live:
+	heroku pg:backups:capture --app tc-hermes
 	heroku pg:backups:download --app tc-hermes
 	make reset-db && time pg_restore --clean --no-acl --no-owner -j12 -h localhost -U postgres -d hermes latest.dump

--- a/README.md
+++ b/README.md
@@ -198,6 +198,14 @@ Ensure admin has a matching email address to the one in the sales or support tea
 
 Unittests can be run with `make test`. You will need to install the test dependencies with `make install-dev` first.
 
+### Testing with live data
+
+to test with live data, run `make restore-from-live` to download and restore the live database to your local machine.
+
+also add your `{your ngork url}/pipedrive/callback` to TutorCruncher Pipedrive webhooks,
+
+then you should see all the webhooks and responses in both your local nrork site and any changes you make in pipedrive will be reflected in your local database.
+
 ## Migrations
 
 We use `aerich` to create and run migrations.

--- a/app/base_schema.py
+++ b/app/base_schema.py
@@ -93,7 +93,6 @@ class HermesBaseModel(BaseModel):
                 if v:
                     try:
                         if is_custom and field_name != 'hermes_id':
-                            debug('custom field reeeeeeeeeeeeeeeee')
                             related_model = model._meta.fields_map[hermes_field_name].related_model
                             related_obj = await related_model.get(**{fk_field_name: v})
                         else:
@@ -104,12 +103,11 @@ class HermesBaseModel(BaseModel):
                         if extra_schema['null_if_invalid']:
                             object_setattr(self, to_field, None)
                         else:
-                            debug(f'{model.__name__} with {fk_field_name} {v} does not exist for {field_info.title}, {field_name}')
                             raise RequestValidationError(
                                 [
                                     {
                                         'loc': [field_name],
-                                        'msg': f'{model.__name__} with {fk_field_name} {v} does not exist', # this could be happening because locally I have the admin with id x but live i dont have that
+                                        'msg': f'{model.__name__} with {fk_field_name} {v} does not exist',
                                         'type': 'value_error',
                                     }
                                 ]

--- a/app/base_schema.py
+++ b/app/base_schema.py
@@ -107,7 +107,7 @@ class HermesBaseModel(BaseModel):
                         related_obj = await model.get(**{fk_field_name: v})
 
                     except DoesNotExist:
-                        if extra_schema['null_if_invalid'] or field_name == 'hermes_id':
+                        if extra_schema['null_if_invalid']:
                             object_setattr(self, to_field, None)
                         else:
                             raise RequestValidationError(

--- a/app/base_schema.py
+++ b/app/base_schema.py
@@ -89,16 +89,17 @@ class HermesBaseModel(BaseModel):
                 to_field = extra_schema['to_field']
                 is_custom = extra_schema['custom']
                 hermes_field_name = extra_schema['hermes_field_name']
-                debug(field_name, field_info.title, model, fk_field_name, to_field, extra_schema, v)
                 if v:
                     try:
+
+                        # If the field is a custom field and not hermes id, we need to get the related object from
+                        # the related model.
                         if is_custom and field_name != 'hermes_id':
                             related_model = model._meta.fields_map[hermes_field_name].related_model
                             related_obj = await related_model.get(**{fk_field_name: v})
                         else:
                             related_obj = await model.get(**{fk_field_name: v})
 
-                        debug(related_obj)
                     except DoesNotExist:
                         if extra_schema['null_if_invalid']:
                             object_setattr(self, to_field, None)

--- a/app/base_schema.py
+++ b/app/base_schema.py
@@ -107,7 +107,7 @@ class HermesBaseModel(BaseModel):
                         related_obj = await model.get(**{fk_field_name: v})
 
                     except DoesNotExist:
-                        if extra_schema['null_if_invalid']:
+                        if extra_schema['null_if_invalid'] or field_name == 'hermes_id':
                             object_setattr(self, to_field, None)
                         else:
                             raise RequestValidationError(

--- a/app/base_schema.py
+++ b/app/base_schema.py
@@ -6,12 +6,18 @@ from pydantic._internal._model_construction import object_setattr
 from pydantic.fields import FieldInfo
 from tortoise.exceptions import DoesNotExist
 from tortoise.query_utils import Prefetch
+
 if TYPE_CHECKING:  # noqa
     from app.models import Company, Contact, CustomField, Deal, Meeting
 
 
 def fk_json_schema_extra(
-    model: Any, fk_field_name: str = 'id', null_if_invalid: bool = False, custom: bool = False, to_field: str = None, hermes_field_name: str = None
+    model: Any,
+    fk_field_name: str = 'id',
+    null_if_invalid: bool = False,
+    custom: bool = False,
+    to_field: str = None,
+    hermes_field_name: str = None,
 ):
     """
     Generates a json schema for a ForeignKeyField field.
@@ -67,13 +73,15 @@ class HermesBaseModel(BaseModel):
         2. If the extra schema information indicates that the field is a foreign key field, it retrieves the model,
            the foreign key field name, and the field to which the foreign key refers. If to_field is set on the class
            attribute, it uses that instead.
-        3. If the value of the field is not None, it tries to get the related object from the database using the
+        3. If the field is custom and the field name is not 'hermes_id', it retrieves the related model from the
+           model's metadata and sets the to_field to the hermes_field_name.
+        4. If the value of the field is not None, it tries to get the related object from the database using the
            foreign key field name and the value.
-        4. If the related object does not exist in the database, it checks if the 'null_if_invalid' flag in the extra
+        5. If the related object does not exist in the database, it checks if the 'null_if_invalid' flag in the extra
            schema is set to True. If it is, it sets the field to None. If it's not, it raises a RequestValidationError.
-        5. If the related object does exist, it sets the field to the related object.
-        6. If the value of the field is None, it sets the field to None.
-        7. If the field value has an 'a_validate' method (indicating that it's a nested model), it calls the
+        6. If the related object does exist, it sets the field to the related object.
+        7. If the value of the field is None, it sets the field to None.
+        8. If the field value has an 'a_validate' method (indicating that it's a nested model), it calls the
            'a_validate' method on the field value.
 
         This method ensures that all foreign key fields in the model are valid and refer to existing objects in the
@@ -89,16 +97,14 @@ class HermesBaseModel(BaseModel):
                 to_field = extra_schema['to_field']
                 is_custom = extra_schema['custom']
                 hermes_field_name = extra_schema['hermes_field_name']
+
+                if is_custom and field_name != 'hermes_id':
+                    model = model._meta.fields_map[hermes_field_name].related_model
+                    to_field = hermes_field_name
+
                 if v:
                     try:
-
-                        # If the field is a custom field and not hermes id, we need to get the related object from
-                        # the related model.
-                        if is_custom and field_name != 'hermes_id':
-                            related_model = model._meta.fields_map[hermes_field_name].related_model
-                            related_obj = await related_model.get(**{fk_field_name: v})
-                        else:
-                            related_obj = await model.get(**{fk_field_name: v})
+                        related_obj = await model.get(**{fk_field_name: v})
 
                     except DoesNotExist:
                         if extra_schema['null_if_invalid']:
@@ -194,7 +200,10 @@ async def get_custom_fieldinfo(
     elif field.field_type == CustomField.TYPE_BOOL:
         field_kwargs.update(annotation=Optional[bool], default=None)
     elif field.field_type == CustomField.TYPE_FK_FIELD:
-        field_kwargs.update(annotation=Optional[int], json_schema_extra=fk_json_schema_extra(model, custom=True, hermes_field_name=field.hermes_field_name))
+        field_kwargs.update(
+            annotation=Optional[int],
+            json_schema_extra=fk_json_schema_extra(model, custom=True, hermes_field_name=field.hermes_field_name),
+        )
     if (
         field.hermes_field_name
         and field.hermes_field_name in model._meta.fields_map

--- a/app/pipedrive/_process.py
+++ b/app/pipedrive/_process.py
@@ -15,6 +15,9 @@ async def _process_pd_organisation(
     TODO: If we can't match the company by it's hermes_id, we should really try and match it by name also. However, as
     of now it should be impossible to create a company in Pipedrive that already exists in Hermes as the only other
     two ways to create a company (from TC2 and the Callbooker) always create the new company in PD.
+
+    if a company is not found in a_validate, then we will also check if it already exists in the db by matching the
+    pd_org_id
     """
     # Company has been set here by Org.a_validate, as we have a custom field `hermes_id` linking it to the Company
     current_company = getattr(current_pd_org, 'company', None) if current_pd_org else None
@@ -67,6 +70,9 @@ async def _process_pd_person(current_pd_person: Optional[Person], old_pd_person:
 
     TODO: If we can't match the contact by it's hermes_id, we should really try and match it by name also. However, I
     don't care enough since Companies are really the only important part.
+
+    if a contact is not found in a_validate, then we will also check if it already exists in the db by matching the
+    pd_person_id
     """
     # Contact has been set here by Person.a_validate, as we have a custom field `hermes_id` linking it to the Contact
     current_contact = getattr(current_pd_person, 'contact', None) if current_pd_person else None

--- a/app/pipedrive/_process.py
+++ b/app/pipedrive/_process.py
@@ -20,7 +20,10 @@ async def _process_pd_organisation(
     current_company = getattr(current_pd_org, 'company', None) if current_pd_org else None
     old_company = getattr(old_pd_org, 'company', None) if old_pd_org else None
 
-    existing_company = await Company.get(pd_org_id=current_pd_org.id) if current_pd_org else None
+    try:
+        existing_company = await Company.get(pd_org_id=current_pd_org.id) if current_pd_org else None
+    except Exception:
+        existing_company = None
     company = current_company or old_company or existing_company
     company_custom_fields = await CustomField.filter(linked_object_type='Company')
     if company:
@@ -69,7 +72,11 @@ async def _process_pd_person(current_pd_person: Optional[Person], old_pd_person:
     current_contact = getattr(current_pd_person, 'contact', None) if current_pd_person else None
     old_contact = getattr(old_pd_person, 'contact', None) if old_pd_person else None
 
-    existing_person = await Contact.get(pd_person_id=current_pd_person.id) if current_pd_person else None
+    try:
+        existing_person = await Contact.get(pd_person_id=current_pd_person.id) if current_pd_person else None
+    except Exception:
+        existing_person = None
+
     contact = current_contact or old_contact or existing_person
     if contact:
         if current_pd_person:

--- a/app/pipedrive/_process.py
+++ b/app/pipedrive/_process.py
@@ -19,10 +19,8 @@ async def _process_pd_organisation(
     # Company has been set here by Org.a_validate, as we have a custom field `hermes_id` linking it to the Company
     current_company = getattr(current_pd_org, 'company', None) if current_pd_org else None
     old_company = getattr(old_pd_org, 'company', None) if old_pd_org else None
-    debug(old_company)
     company = current_company or old_company
     company_custom_fields = await CustomField.filter(linked_object_type='Company')
-    debug(company)
     if company:
         if current_pd_org:
             # The org has been updated
@@ -46,8 +44,6 @@ async def _process_pd_organisation(
     elif current_pd_org:
         # The org has just been created
         company = await Company.create(**await current_pd_org.company_dict(company_custom_fields))
-        debug('down here')
-        debug(company)
         # post to pipedrive to update the hermes_id
         app_logger.info('Callback: creating Company %s from Organisation %s', company.id, current_pd_org.id)
         new_company_cf_vals = await current_pd_org.custom_field_values(company_custom_fields)

--- a/app/pipedrive/_process.py
+++ b/app/pipedrive/_process.py
@@ -82,7 +82,7 @@ async def _process_pd_person(current_pd_person: Optional[Person], old_pd_person:
 
     try:
         existing_person = await Contact.get(pd_person_id=current_pd_person.id) if current_pd_person else None
-    except Exception:
+    except DoesNotExist:
         existing_person = None
 
     contact = current_contact or old_contact or existing_person

--- a/app/pipedrive/_process.py
+++ b/app/pipedrive/_process.py
@@ -19,6 +19,7 @@ async def _process_pd_organisation(
     # Company has been set here by Org.a_validate, as we have a custom field `hermes_id` linking it to the Company
     current_company = getattr(current_pd_org, 'company', None) if current_pd_org else None
     old_company = getattr(old_pd_org, 'company', None) if old_pd_org else None
+
     company = current_company or old_company
     company_custom_fields = await CustomField.filter(linked_object_type='Company')
     if company:

--- a/app/pipedrive/_process.py
+++ b/app/pipedrive/_process.py
@@ -19,8 +19,10 @@ async def _process_pd_organisation(
     # Company has been set here by Org.a_validate, as we have a custom field `hermes_id` linking it to the Company
     current_company = getattr(current_pd_org, 'company', None) if current_pd_org else None
     old_company = getattr(old_pd_org, 'company', None) if old_pd_org else None
+    debug(old_company)
     company = current_company or old_company
     company_custom_fields = await CustomField.filter(linked_object_type='Company')
+    debug(company)
     if company:
         if current_pd_org:
             # The org has been updated
@@ -44,6 +46,8 @@ async def _process_pd_organisation(
     elif current_pd_org:
         # The org has just been created
         company = await Company.create(**await current_pd_org.company_dict(company_custom_fields))
+        debug('down here')
+        debug(company)
         # post to pipedrive to update the hermes_id
         app_logger.info('Callback: creating Company %s from Organisation %s', company.id, current_pd_org.id)
         new_company_cf_vals = await current_pd_org.custom_field_values(company_custom_fields)

--- a/app/pipedrive/_process.py
+++ b/app/pipedrive/_process.py
@@ -20,7 +20,8 @@ async def _process_pd_organisation(
     current_company = getattr(current_pd_org, 'company', None) if current_pd_org else None
     old_company = getattr(old_pd_org, 'company', None) if old_pd_org else None
 
-    company = current_company or old_company
+    existing_company = await Company.get(pd_org_id=current_pd_org.id) if current_pd_org else None
+    company = current_company or old_company or existing_company
     company_custom_fields = await CustomField.filter(linked_object_type='Company')
     if company:
         if current_pd_org:
@@ -67,7 +68,9 @@ async def _process_pd_person(current_pd_person: Optional[Person], old_pd_person:
     # Contact has been set here by Person.a_validate, as we have a custom field `hermes_id` linking it to the Contact
     current_contact = getattr(current_pd_person, 'contact', None) if current_pd_person else None
     old_contact = getattr(old_pd_person, 'contact', None) if old_pd_person else None
-    contact = current_contact or old_contact
+
+    existing_person = await Contact.get(pd_person_id=current_pd_person.id) if current_pd_person else None
+    contact = current_contact or old_contact or existing_person
     if contact:
         if current_pd_person:
             # The person has been updated

--- a/app/pipedrive/_process.py
+++ b/app/pipedrive/_process.py
@@ -1,9 +1,10 @@
 from typing import Optional
 
+from tortoise.exceptions import DoesNotExist
+
 from app.models import Company, Contact, CustomField, Deal, Pipeline, Stage
 from app.pipedrive._schema import Organisation, PDDeal, PDPipeline, PDStage, Person
 from app.pipedrive._utils import app_logger
-from tortoise.exceptions import DoesNotExist
 
 
 async def _process_pd_organisation(

--- a/app/pipedrive/_process.py
+++ b/app/pipedrive/_process.py
@@ -3,6 +3,7 @@ from typing import Optional
 from app.models import Company, Contact, CustomField, Deal, Pipeline, Stage
 from app.pipedrive._schema import Organisation, PDDeal, PDPipeline, PDStage, Person
 from app.pipedrive._utils import app_logger
+from tortoise.exceptions import DoesNotExist
 
 
 async def _process_pd_organisation(
@@ -25,7 +26,7 @@ async def _process_pd_organisation(
 
     try:
         existing_company = await Company.get(pd_org_id=current_pd_org.id) if current_pd_org else None
-    except Exception:
+    except DoesNotExist:
         existing_company = None
     company = current_company or old_company or existing_company
     company_custom_fields = await CustomField.filter(linked_object_type='Company')

--- a/app/pipedrive/_schema.py
+++ b/app/pipedrive/_schema.py
@@ -43,6 +43,7 @@ class PipedriveBaseModel(HermesBaseModel):
         When updating a Hermes model from a Pipedrive webhook, we need to get the custom field values from the
         Pipedrive model.
         """
+        debug(custom_fields)
         return {c.id: getattr(self, c.machine_name) for c in custom_fields if not c.hermes_field_name}
 
 
@@ -65,7 +66,6 @@ class Organisation(PipedriveBaseModel):
             tc2_cligency_url=company.tc2_cligency_url,
             address_country=company.country,
         )
-
         cls_kwargs.update(await cls.get_custom_field_vals(company))
         final_kwargs = _remove_nulls(**cls_kwargs)
         return cls(**final_kwargs)
@@ -285,6 +285,7 @@ class PipedriveEvent(HermesBaseModel):
         rebuild the model when adding custom fields.
         """
         if v['obj_type'] == 'organization':
+            debug(Organisation(**v))
             return Organisation(**v)
         elif v['obj_type'] == 'person':
             return Person(**v)

--- a/app/pipedrive/_schema.py
+++ b/app/pipedrive/_schema.py
@@ -43,7 +43,6 @@ class PipedriveBaseModel(HermesBaseModel):
         When updating a Hermes model from a Pipedrive webhook, we need to get the custom field values from the
         Pipedrive model.
         """
-        debug(custom_fields)
         return {c.id: getattr(self, c.machine_name) for c in custom_fields if not c.hermes_field_name}
 
 
@@ -285,7 +284,6 @@ class PipedriveEvent(HermesBaseModel):
         rebuild the model when adding custom fields.
         """
         if v['obj_type'] == 'organization':
-            debug(Organisation(**v))
             return Organisation(**v)
         elif v['obj_type'] == 'person':
             return Person(**v)

--- a/app/pipedrive/views.py
+++ b/app/pipedrive/views.py
@@ -23,6 +23,7 @@ async def callback(event: PipedriveEvent, tasks: BackgroundTasks):
     """
     event.current and await event.current.a_validate()
     event.previous and await event.previous.a_validate()
+
     app_logger.info(f'Callback: event received for {event.meta.object}: {event}')
     if event.meta.object == 'deal':
         deal = await _process_pd_deal(event.current, event.previous)

--- a/app/pipedrive/views.py
+++ b/app/pipedrive/views.py
@@ -21,11 +21,8 @@ async def callback(event: PipedriveEvent, tasks: BackgroundTasks):
     Processes a Pipedrive event. If a Deal is updated then we run a background task to update the cligency in Pipedrive
     TODO: This has 0 security, we should add some.
     """
-    debug('before validation')
-    debug(event)
     event.current and await event.current.a_validate()
     event.previous and await event.previous.a_validate()
-    debug('after validation')
     app_logger.info(f'Callback: event received for {event.meta.object}: {event}')
     if event.meta.object == 'deal':
         deal = await _process_pd_deal(event.current, event.previous)

--- a/app/pipedrive/views.py
+++ b/app/pipedrive/views.py
@@ -21,8 +21,11 @@ async def callback(event: PipedriveEvent, tasks: BackgroundTasks):
     Processes a Pipedrive event. If a Deal is updated then we run a background task to update the cligency in Pipedrive
     TODO: This has 0 security, we should add some.
     """
+    debug('before validation')
+    debug(event)
     event.current and await event.current.a_validate()
     event.previous and await event.previous.a_validate()
+    debug('after validation')
     app_logger.info(f'Callback: event received for {event.meta.object}: {event}')
     if event.meta.object == 'deal':
         deal = await _process_pd_deal(event.current, event.previous)

--- a/tests/test_combined.py
+++ b/tests/test_combined.py
@@ -1,3 +1,4 @@
+import copy
 import hashlib
 import hmac
 import json
@@ -9,7 +10,7 @@ from app.pipedrive.tasks import pd_post_process_client_event
 from app.utils import settings
 from tests._common import HermesTestCase
 from tests.test_callbooker import fake_gcal_builder
-from tests.test_pipedrive import FakePipedrive, fake_pd_request
+from tests.test_pipedrive import FakePipedrive, fake_pd_request, basic_pd_org_data
 from tests.test_tc2 import client_full_event_data, mock_tc2_request
 
 
@@ -187,6 +188,57 @@ class TestMultipleServices(HermesTestCase):
 
         await tc2_cligency_url.delete()
         await build_custom_field_schema()
+
+    @mock.patch('app.tc2.api.session.request')
+    @mock.patch('app.pipedrive.api.session.request')
+    async def test_pipedrive_cb_org_exists_no_hermes_id_match(self, mock_pd_request, mock_tc2_get):
+        mock_pd_request.side_effect = fake_pd_request(self.pipedrive)
+        mock_tc2_get.side_effect = mock_tc2_request()
+
+        admin = await Admin.create(
+            tc2_admin_id=30,
+            first_name='Brain',
+            last_name='Johnson',
+            username='brian@tc.com',
+            password='foo',
+            pd_owner_id=10,
+        )
+
+        # The lost org in pipedrive that needs to be updated
+        self.pipedrive.db['organizations'] = {
+            1: {
+                'id': 1,
+                'name': 'MyTutors',
+                'address_country': 'GB',
+                'owner_id': 99,
+                '123_hermes_id_456': 999,
+            }
+        }
+
+        data = copy.deepcopy(basic_pd_org_data())
+        data['previous'] = copy.deepcopy(data['current'])
+        data['current'].update(name='New test company')
+
+        r = await self.client.post('/pipedrive/callback/', json=data)
+        assert r.status_code == 200, r.json()
+
+        assert await Company.exists()
+        company = await Company.get()
+
+        debug(company)
+        await pd_post_process_client_event(company=company)
+        debug('ree')
+        # Check the org has been updated
+        assert self.pipedrive.db['organizations'] == {
+            1: {
+                'id': 1,
+                'name': 'New test company',
+                'address_country': 'GB',
+                'owner_id': 10,
+                '123_hermes_id_456': company.id,
+            }
+        }
+
 
     @mock.patch('app.callbooker._google.AdminGoogleCalendar._create_resource')
     @mock.patch('app.tc2.api.session.request')

--- a/tests/test_pipedrive.py
+++ b/tests/test_pipedrive.py
@@ -1665,10 +1665,18 @@ class PipedriveCallbackTestCase(HermesTestCase):
         data = copy.deepcopy(basic_pd_org_data())
         data['current']['123_hermes_id_456'] = 75
         r = await self.client.post(self.url, json=data)
-        assert r.status_code == 200, r.json()
-        company = await Company.get()
-        assert company.name == 'Test company'
-        assert company.sales_person_id == self.admin.id
+        assert r.status_code == 422, r.json()
+        assert r.json() == {
+            'detail': [
+                {
+                    'loc': [
+                        'hermes_id',
+                    ],
+                    'msg': 'Company with id 75 does not exist',
+                    'type': 'value_error',
+                },
+            ],
+        }
 
     @mock.patch('app.pipedrive.api.session.request')
     async def test_org_create_no_custom_fields(self, mock_request):

--- a/tests/test_pipedrive.py
+++ b/tests/test_pipedrive.py
@@ -1983,7 +1983,7 @@ class PipedriveCallbackTestCase(HermesTestCase):
             pd_owner_id=99,
         )
 
-        source_field = await CustomField.create(
+        support_person_field = await CustomField.create(
             linked_object_type='Company',
             pd_field_id='123_support_person_id_456',
             hermes_field_name='support_person',
@@ -1995,7 +1995,7 @@ class PipedriveCallbackTestCase(HermesTestCase):
         mock_request.side_effect = fake_pd_request(self.pipedrive)
         company = await Company.create(name='Old test company', sales_person=self.admin)
 
-        await CustomFieldValue.create(custom_field=source_field, company=company, value=admin.id)
+        await CustomFieldValue.create(custom_field=support_person_field, company=company, value=admin.id)
 
         data = copy.deepcopy(basic_pd_org_data())
         data['previous'] = copy.deepcopy(data['current'])
@@ -2013,9 +2013,9 @@ class PipedriveCallbackTestCase(HermesTestCase):
 
         cf_val = await CustomFieldValue.get()
         assert cf_val.value == str(admin.id)
-        assert await cf_val.custom_field == source_field
+        assert await cf_val.custom_field == support_person_field
 
-        await source_field.delete()
+        await support_person_field.delete()
         await build_custom_field_schema()
 
     @mock.patch('app.pipedrive.api.session.request')
@@ -2071,8 +2071,9 @@ class PipedriveCallbackTestCase(HermesTestCase):
 
     @mock.patch('app.pipedrive.api.session.request')
     async def test_org_update_no_hermes_id(self, mock_request):
-        await Company.create(name='Old test company', sales_person=self.admin, pd_org_id=20)
         mock_request.side_effect = fake_pd_request(self.pipedrive)
+
+        await Company.create(name='Old test company', sales_person=self.admin, pd_org_id=20)
         data = copy.deepcopy(basic_pd_org_data())
         data['previous'] = copy.deepcopy(data['current'])
         data['current'].update(name='New test company')

--- a/tests/test_pipedrive.py
+++ b/tests/test_pipedrive.py
@@ -1961,6 +1961,49 @@ class PipedriveCallbackTestCase(HermesTestCase):
         await build_custom_field_schema()
 
     @mock.patch('app.pipedrive.api.session.request')
+    async def test_org_update_associated_custom_fk_field(self, mock_request):
+
+        admin = await Admin.create(
+            first_name='Steve',
+            last_name='Jobs',
+            username='climan@example.com',
+            is_sales_person=True,
+            tc2_admin_id=20,
+            pd_owner_id=99,
+        )
+
+        source_field = await CustomField.create(
+            linked_object_type='Company',
+            pd_field_id='123_support_person_id_456',
+            hermes_field_name='support_person',
+            name='Support Person ID',
+            field_type=CustomField.TYPE_FK_FIELD,
+        )
+
+        await build_custom_field_schema()
+        mock_request.side_effect = fake_pd_request(self.pipedrive)
+        company = await Company.create(name='Old test company', sales_person=self.admin)
+
+        cfv = await CustomFieldValue.create(custom_field=source_field, company=company, value=admin.id)
+        debug(cfv.__dict__)
+
+        data = copy.deepcopy(basic_pd_org_data())
+        data['previous'] = copy.deepcopy(data['current'])
+        data['previous'].update(hermes_id=company.id)
+        data['current'].update(**{'name': 'New test company', '123_support_person_id_456': admin.id})
+        r = await self.client.post(self.url, json=data)
+        assert r.status_code == 200, r.json()
+        company = await Company.get()
+        assert company.name == 'New test company'
+
+        cf_val = await CustomFieldValue.get()
+        assert cf_val.value == admin.id
+        assert await cf_val.custom_field == source_field
+
+        await source_field.delete()
+        await build_custom_field_schema()
+
+    @mock.patch('app.pipedrive.api.session.request')
     async def test_org_update_custom_field_val_deleted(self, mock_request):
         source_field = await CustomField.create(
             linked_object_type='Company',

--- a/tests/test_pipedrive.py
+++ b/tests/test_pipedrive.py
@@ -1659,6 +1659,18 @@ class PipedriveCallbackTestCase(HermesTestCase):
         assert company.sales_person_id == self.admin.id
 
     @mock.patch('app.pipedrive.api.session.request')
+    async def test_org_create_with_hermes_id_company_missing(self, mock_request):
+        mock_request.side_effect = fake_pd_request(self.pipedrive)
+        assert not await Company.exists()
+        data = copy.deepcopy(basic_pd_org_data())
+        data['current']['123_hermes_id_456'] = 75
+        r = await self.client.post(self.url, json=data)
+        assert r.status_code == 200, r.json()
+        company = await Company.get()
+        assert company.name == 'Test company'
+        assert company.sales_person_id == self.admin.id
+
+    @mock.patch('app.pipedrive.api.session.request')
     async def test_org_create_no_custom_fields(self, mock_request):
         mock_request.side_effect = fake_pd_request(self.pipedrive)
         await CustomField.all().delete()


### PR DESCRIPTION
Fix #185 
## Technical Description
### 1
- in `a_validate` if we can not retrieve the related obj for `hermes_id` then we ~~set it to none~~ This should not occur, and if it does we want the 422 error to tell us why

### 2
- in `_process_pd_person` and `_process_pd_organisation` if the `Company` or `Contact` can not be returned then we get the "existing one" by matching the `pd_person_id` or `pd_org_id`
 
### 3
- Modified `a_validate` when a custom field is a foreign key and not 'hermes_id' we set the model from the model meta data.
i.e
`bdr_person_id` - custom field
`Company` - linked object type
therefore to get the correct foreign key model --> Company[bdr_person].related_model = Admin
- `to_field` is used to tell a_validate what the foreign key referrs too.
	- previously it populated based off the linked object model now it populates by the `hermes_field_name`



I also added `make restore-from-live` that downloads the latest live db from heroku and restores your local to it.
