### PR TITLE
remove sentry integrations

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8,8 +8,6 @@ from fastapi.staticfiles import StaticFiles
 from fastapi_admin.app import app as admin_app
 from logfire import PydanticPlugin
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
-from sentry_sdk.integrations.fastapi import FastApiIntegration
-from sentry_sdk.integrations.starlette import StarletteIntegration
 from starlette.middleware.cors import CORSMiddleware
 from tortoise.contrib.fastapi import register_tortoise
 
@@ -26,14 +24,7 @@ from app.tc2.views import tc2_router
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 _app_settings = Settings()
 if _app_settings.sentry_dsn:
-    sentry_sdk.init(
-        dsn=_app_settings.sentry_dsn,
-        enable_tracing=True,
-        integrations=[
-            StarletteIntegration(transaction_style='endpoint'),
-            FastApiIntegration(transaction_style='endpoint'),
-        ],
-    )
+    sentry_sdk.init(dsn=_app_settings.sentry_dsn,)
 
 app = FastAPI()
 


### PR DESCRIPTION
Fix #191

I added these integrations to sentry to try and get more reporting, but i think it messed it up and now we have less :/

so i have reverted them.﻿
