### PR TITLE
Fix `termination_category` error

### DIFF
--- a/app/tc2/_schema.py
+++ b/app/tc2/_schema.py
@@ -81,7 +81,10 @@ class TCClientExtraAttr(HermesBaseModel):
 
     @field_validator('value')
     @classmethod
-    def validate_value(cls, v):
+    def validate_value(cls, v, values):
+        if values.data['machine_name'] == 'termination_category':
+            debug('Termination category', v)
+            return v
         return v.lower().strip().strip('-')
 
 

--- a/app/tc2/_schema.py
+++ b/app/tc2/_schema.py
@@ -83,7 +83,6 @@ class TCClientExtraAttr(HermesBaseModel):
     @classmethod
     def validate_value(cls, v, values):
         if values.data['machine_name'] == 'termination_category':
-            debug('Termination category', v)
             return v
         return v.lower().strip().strip('-')
 

--- a/app/tc2/api.py
+++ b/app/tc2/api.py
@@ -12,7 +12,7 @@ session = requests.Session()
 
 async def tc2_request(url: str, *, method: str = 'GET', data: dict = None) -> dict:
     headers = {'Authorization': f'token {settings.tc2_api_key}', 'Content-Type': 'application/json'}
-    logfire.debug('TutorCruncher request to url: {url=}: {data=}', url=url, data=data)
+    app_logger.info('TutorCruncher request to url: %s: %s', url, data)
     with logfire.span('{method} {url!r}', url=url, method=method):
         r = session.request(method=method, url=f'{settings.tc2_base_url}/api/{url}', json=data, headers=headers)
     app_logger.info('Request method=%s url=%s status_code=%s', method, url, r.status_code, extra={'data': data})

--- a/app/tc2/tasks.py
+++ b/app/tc2/tasks.py
@@ -33,8 +33,7 @@ async def update_client_from_company(company: Company):
             extra_attrs[cf.tc2_machine_name] = val
         client_data = tc_client.model_dump()
         client_data['extra_attrs'] = extra_attrs
-        with logfire.span('Updating Cligency from Company'):
-            assert False
+        with logfire.span('Updating TC2 Cligency from Company'):
             await tc2_request('clients/', method='POST', data=client_data)
 
 

--- a/app/tc2/tasks.py
+++ b/app/tc2/tasks.py
@@ -1,12 +1,12 @@
 from typing import Type
 
+import logfire
 from tortoise.query_utils import Prefetch
 
 from app.base_schema import HermesBaseModel
 from app.models import Company, CustomField, CustomFieldValue, Deal
 from app.tc2._schema import TCClient
 from app.tc2.api import tc2_request
-import logfire
 
 
 async def update_client_from_company(company: Company):

--- a/app/tc2/tasks.py
+++ b/app/tc2/tasks.py
@@ -6,6 +6,7 @@ from app.base_schema import HermesBaseModel
 from app.models import Company, CustomField, CustomFieldValue, Deal
 from app.tc2._schema import TCClient
 from app.tc2.api import tc2_request
+import logfire
 
 
 async def update_client_from_company(company: Company):
@@ -32,7 +33,9 @@ async def update_client_from_company(company: Company):
             extra_attrs[cf.tc2_machine_name] = val
         client_data = tc_client.model_dump()
         client_data['extra_attrs'] = extra_attrs
-        await tc2_request('clients/', method='POST', data=client_data)
+        with logfire.span('Updating Cligency from Company'):
+            assert False
+            await tc2_request('clients/', method='POST', data=client_data)
 
 
 MODEL_TC2_LU = {Company: TCClient}

--- a/tests/test_tc2.py
+++ b/tests/test_tc2.py
@@ -84,6 +84,18 @@ def client_deleted_event_data():
         },
     }
 
+def client_edited_event_data():
+    return {
+        'action': 'EDITED_A_CLIENT',
+        'verb': 'Edited a Client',
+        'subject': {
+            'id': 10,
+            'model': 'Client',
+            'first_name': 'Harry',
+            'last_name': 'Poster',
+        },
+    }
+
 
 def invoice_event_data():
     return {
@@ -553,27 +565,6 @@ class TC2CallbackTestCase(HermesTestCase):
         assert r.status_code == 200, r.json()
         assert await Company.all().count() == 0
 
-    async def test_cb_client_deleted_no_linked_data(self):
-        """
-        Company deleted, has no contacts
-        """
-        admin = await Admin.create(
-            tc2_admin_id=30, first_name='Brain', last_name='Johnson', username='brian@tc.com', password='foo'
-        )
-        await Company.create(
-            tc2_agency_id=20, tc2_cligency_id=10, name='OurTutors', status='inactive', country='GB', sales_person=admin
-        )
-
-        modified_data = client_deleted_event_data()
-        modified_data['subject']['extra_attrs'] = [
-            {'machine_name': 'termination_category', 'value': 'Too Complicated'},
-        ]
-        events = [modified_data]
-        data = {'_request_time': 123, 'events': events}
-        r = await self.client.post(self.url, json=data, headers={'Webhook-Signature': self._tc2_sig(data)})
-        assert r.status_code == 200, r.json()
-        assert await Company.all().count() == 0
-
     async def test_cb_client_deleted_test_has_linked_data(self):
         """
         Company deleted, has contact
@@ -918,3 +909,66 @@ class TC2TasksTestCase(HermesTestCase):
         await pipedrive_id_field.delete()
         await domain_field.delete()
         await build_custom_field_schema()
+
+
+class TC2TasksAndClassTestCase(HermesTestCase):
+    def setUp(self):
+        super().setUp()
+        self.tc2 = FakeTC2()
+        self.tc_callback_url = '/tc2/callback/'
+
+    def _tc2_sig(self, payload):
+        return hmac.new(settings.tc2_api_key.encode(), json.dumps(payload).encode(), hashlib.sha256).hexdigest()
+
+
+    @mock.patch('app.tc2.api.session.request')
+    async def test_cb_client_deleted_no_linked_data_update_cligency(self, mock_request):
+        """
+        Company deleted, has no contacts
+        """
+        # Handle the callback from TC2 to delete a company
+        admin = await Admin.create(
+            tc2_admin_id=30, first_name='Brain', last_name='Johnson', username='brian@tc.com', password='foo'
+        )
+        company = await Company.create(
+            tc2_agency_id=20, tc2_cligency_id=10, name='OurTutors', status='inactive', country='GB', sales_person=admin
+        )
+
+        modified_data = client_deleted_event_data()
+        modified_data['subject']['extra_attrs'] = [
+            {'machine_name': 'termination_category', 'value': 'Too Complicated'},
+        ]
+        events = [modified_data]
+        data = {'_request_time': 123, 'events': events}
+        r = await self.client.post(self.tc_callback_url, json=data, headers={'Webhook-Signature': self._tc2_sig(data)})
+        assert r.status_code == 200, r.json()
+        assert await Company.all().count() == 0
+
+        # Handle the post to TC2 to update the cligency
+        mock_request.side_effect = fake_tc2_request(self.tc2)
+        await update_client_from_company(company)
+        assert self.tc2.db['clients'] == {
+            10: {
+                'user': {
+                    'email': 'mary@booth.com',
+                    'phone': None,
+                    'first_name': 'Mary',
+                    'last_name': 'Booth',
+                },
+                'status': 'live',
+                'sales_person_id': 30,
+                'associated_admin_id': 30,
+                'bdr_person_id': None,
+                'paid_recipients': [
+                    {
+                        'email': 'mary@booth.com',
+                        'first_name': 'Mary',
+                        'last_name': 'Booth',
+                    },
+                ],
+                'extra_attrs': {
+                    'pipedrive_url': f'{settings.pd_base_url}/organization/20/',
+                    'who_are_you_trying_to_reach': 'support',
+                },
+            }
+        }


### PR DESCRIPTION
Fix https://github.com/tutorcruncher/TutorCruncher2/issues/13663

## Problem

So a agency is being terminated on TC2:
which then sends a webhook to hermes
then updates hermes
hermes sends request to PD to update Org
﻿PD sends webhook to hermes with to update Company
hermes `update client from company` to update Cliegency in TC2 
this is wher ethe error is as the extra_attrs, termination category is set to.lower() 

## Recreate


