### PR TITLE
Fix Organisaition Admins, for BDR, Sales

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Create 5 Admins in TC2, for each of the following:
 - bdr
   
 #### Meta Client Custom Fields:
-Navigate to ... > Settings > Custom Fields > Add Custom Field
+Navigate to System > Settings > Custom Fields > Add Custom Field
 ```
 estimated_monthly_income: str (Short Textbox)     # estimated monthly income of the Cligency
 utm_source: str (Short Textbox)                  # utm source of the Cligency
@@ -63,8 +63,6 @@ utm_campaign: str (Short Textbox)                # utm campaign of the Cligency
 currency: str (Short Textbox)                    # currency of the Cligency
 referer: str (Short Textbox)                     # referer of the Cligency
 ```
-
-`bdr_person_id` ??
   
 #### Add API Integration to META:  
 
@@ -90,6 +88,9 @@ Navigate to Profile > Tools and apps > Webhooks > Create 7 new webhooks:
 Navigate to Company Settings > Data Fields
 
 ###### Organization Default Custom Fields:
+
+Hint: Look at Extra Tips (at the bottom of README) for a more detailed guide on how to add a new custom field to Pipedrive
+
 ```  
 website  
 paid_invoice_count  
@@ -97,14 +98,17 @@ paid_invoice_count
 [//]: # (has_booked_call  )
 
 [//]: # (has_signed_up  )
-tc2_status  
-tc2_cligency_url
-hermes_id
-bdr_person_id
-utm_campaign
-utm_source
-estimated_monthly_income
-currency
+tc2_status: Large text  
+tc2_cligency_url: Large text
+hermes_id: Numerical
+bdr_person_id: Numerical
+utm_campaign: Large text
+utm_source: Large text
+estimated_monthly_income: Large text
+currency: Large text
+support_person_id: Numerical
+signup_questionnaire: Large text
+website: Large text
 ```  
 ###### Person Default Custom Fields:
 ```
@@ -117,18 +121,18 @@ hermes_id
 
 #### Setup Pipedrive Users:
 
-Navigate to ... > User Overview > Add User
+-> Navigate to Company settings > Manage users > Add User
 
 Now we should setup a couple of users in Pipedrive:
 - `payg / startup sales`
 - `enterprise sales`
 - `bdr`
 
-You can user your email address for each user, i.e sebastian+pdbdrperson@tutorcruncher.com
+You can use your email address for each user, i.e sebastian+pdbdrperson@tutorcruncher.com
 
 
 Get your Pipedrive Owner ID for your Hermes Admins:  
-- Navigate to ... > User Overview > select your user  
+- Navigate to ... -> Navigate to Company settings > Manage users > select your user  
 - Copy the number at the end of the URL
 
   
@@ -199,21 +203,21 @@ Data fields > Choose the object tab (Lead/deal, Person, Organization, Product), 
 
 #### Template Custom Field setup:  
 
-| ID | machine_name | name | field_type | hermes_field_name | tc2_machine_name | pd_field_id | linked_object_type |
-|---|-------------|------|------------|-------------------|------------------|-------------|--------------------|
-| 1 | website | Website | str        | website           |  | xxxxxxxxxxx | Company            |
-| 2 | paid_invoice_count | Paid Invoice Count | int        | paid_invoice_count |  | xxxxxxxxxxx | Company            |
-| 3 | tc2_status | TC2 Status | str        | tc2_status        |  | xxxxxxxxxxx | Company            |
-| 4 | tc2_cligency_url | TC2 Cligency URL | str        | tc2_cligency_url  |  | xxxxxxxxxxx | Company            |
-| 5 | utm_source | UTM Source | str        | utm_source        |  | xxxxxxxxxxx | Company            |
-| 6 | utm_campaign | UTM Campaign | str        | utm_campaign      |  | xxxxxxxxxxx | Company            |
+| ID | machine_name | name | field_type | hermes_field_name | tc2_machine_name         | pd_field_id | linked_object_type |
+|---|-------------|------|------------|-------------------|--------------------------|-------------|--------------------|
+| 1 | website | Website | str        | website           | website                  | xxxxxxxxxxx | Company            |
+| 2 | paid_invoice_count | Paid Invoice Count | int        | paid_invoice_count |                          | xxxxxxxxxxx | Company            |
+| 3 | tc2_status | TC2 Status | str        | tc2_status        |                          | xxxxxxxxxxx | Company            |
+| 4 | tc2_cligency_url | TC2 Cligency URL | str        | tc2_cligency_url  |                          | xxxxxxxxxxx | Company            |
+| 5 | utm_source | UTM Source | str        | utm_source        | utm_source               | xxxxxxxxxxx | Company            |
+| 6 | utm_campaign | UTM Campaign | str        | utm_campaign      | utm_campaign             | xxxxxxxxxxx | Company            |
 | 7 | estimated_monthly_income | Estimated Monthly Income | str        | estimated_income | estimated_monthly_income | xxxxxxxxxxx | Company            |
-| 8 | currency | Currency | str        | currency          | currency | xxxxxxxxxxx | Company            |
-| 8 | support_person_id | Support Person ID | int        | support_person    |  | xxxxxxxxxxx | Company            |
-| 9 | bdr_person_id | BDR Person ID | int        | bdr_person        |  | xxxxxxxxxxx | Company            |
-| 10 | hermes_id | Hermes ID | fk_field   | id                |  | xxxxxxxxxxx | Company            |
-| 11 | hermes_id | Hermes ID | fk_field        | id                |  | xxxxxxxxxxx | Contact            |
-| 12 | hermes_id | Hermes ID | fk_field        | id                |  | xxxxxxxxxxx | Deal               |
+| 8 | currency | Currency | str        | currency          | currency                 | xxxxxxxxxxx | Company            |
+| 8 | support_person_id | Support Person ID | fk_field   | support_person    |                          | xxxxxxxxxxx | Company            |
+| 9 | bdr_person_id | BDR Person ID | fk_field   | bdr_person        |                          | xxxxxxxxxxx | Company            |
+| 10 | hermes_id | Hermes ID | fk_field   | id                |                          | xxxxxxxxxxx | Company            |
+| 11 | hermes_id | Hermes ID | fk_field   | id                |                          | xxxxxxxxxxx | Contact            |
+| 12 | hermes_id | Hermes ID | fk_field   | id                |                          | xxxxxxxxxxx | Deal               |
 
 
 - replace `xxxxxxxxxxx` with the `pd_field_id` from pipedrive, you can get this by selecting the field in pipedrive and selecting the ... then `Copy API key`
@@ -262,7 +266,7 @@ Now edit each pipeline and set the `dft_entry_pipeline_stage` to the stage that 
 
 #### Config Tab  
 
-- Set Price Plan Pipelines to their associated Hermes Pipeline ID
+- Edit existing config and set the pipline stages to their associated Hermes Stage IDs
 
 
 #### Setup Callbooker:  

--- a/app/admin/resources.py
+++ b/app/admin/resources.py
@@ -72,6 +72,12 @@ class AdminResource(Model):
         Field('sells_payg', label='Sells PAYG', input_=inputs.Switch()),
         Field('sells_startup', label='Sells startup', input_=inputs.Switch()),
         Field('sells_enterprise', label='Sells enterprise', input_=inputs.Switch()),
+        Field('sells_us', label='Sells US', input_=inputs.Switch()),
+        Field('sells_gb', label='Sells GB', input_=inputs.Switch()),
+        Field('sells_au', label='Sells AU', input_=inputs.Switch()),
+        Field('sells_eu', label='Sells EU', input_=inputs.Switch()),
+        Field('sells_ca', label='Sells CA', input_=inputs.Switch()),
+        Field('sells_row', label='Sells ROW', input_=inputs.Switch()),
     ]
 
     async def get_actions(self, request: Request) -> list[Action]:

--- a/app/models.py
+++ b/app/models.py
@@ -101,6 +101,13 @@ class Admin(AbstractAdmin):
     sells_startup = fields.BooleanField(default=False)
     sells_enterprise = fields.BooleanField(default=False)
 
+    sells_us = fields.BooleanField(default=False)
+    sells_gb = fields.BooleanField(default=False)
+    sells_au = fields.BooleanField(default=False)
+    sells_ca = fields.BooleanField(default=False)
+    sells_eu = fields.BooleanField(default=False)
+    sells_row = fields.BooleanField(default=False)
+
     password = fields.CharField(max_length=255, null=True)
 
     deals: fields.ReverseRelation['Deal']
@@ -138,6 +145,12 @@ class Admin(AbstractAdmin):
                 'sells_payg',
                 'sells_startup',
                 'sells_enterprise',
+                'sells_us',
+                'sells_gb',
+                'sells_au',
+                'sells_ca',
+                'sells_eu',
+                'sells_row',
             ),
         )
 

--- a/app/pipedrive/_process.py
+++ b/app/pipedrive/_process.py
@@ -31,10 +31,8 @@ async def _process_pd_organisation(
         existing_company = None
     company = current_company or old_company or existing_company
     company_custom_fields = await CustomField.filter(linked_object_type='Company')
-    debug(company_custom_fields)
     if company:
         if current_pd_org:
-            debug('Processing company')
             # The org has been updated
             old_org_data = old_pd_org and await old_pd_org.company_dict(company_custom_fields)
             new_org_data = await current_pd_org.company_dict(company_custom_fields)
@@ -50,18 +48,15 @@ async def _process_pd_organisation(
                     'Callback: updating Company %s cf values from Organisation %s', company.id, current_pd_org.id
                 )
         else:
-            debug('Deleting company')
             # The org has been deleted. The linked custom fields will also be deleted
             await company.delete()
             app_logger.info('Callback: deleting Company %s from Organisation %s', company.id, old_pd_org.id)
     elif current_pd_org:
-        debug('Creating company')
         # The org has just been created
-        company = await Company.create(**await current_pd_org.create_company_dict(company_custom_fields)) # this is the only place where we create a Company from the pd_org_info
+        company = await Company.create(**await current_pd_org.company_dict(company_custom_fields))
         # post to pipedrive to update the hermes_id
         app_logger.info('Callback: creating Company %s from Organisation %s', company.id, current_pd_org.id)
         new_company_cf_vals = await current_pd_org.custom_field_values(company_custom_fields)
-        debug(new_company_cf_vals)
         cfs_created = await company.process_custom_field_vals({}, new_company_cf_vals)
         if cfs_created:
             app_logger.info(

--- a/app/pipedrive/_schema.py
+++ b/app/pipedrive/_schema.py
@@ -79,6 +79,8 @@ class Organisation(PipedriveBaseModel):
             'pd_org_id': self.id,
             'name': self.name,
             'sales_person_id': self.admin.id,  # noqa: F821 - Added in a_validate
+            'support_person_id': self.support_person.id,
+            'bdr_person_id': self.bdr_person.id,
             **_remove_nulls(**cf_data_from_hermes),
         }
 

--- a/app/pipedrive/_schema.py
+++ b/app/pipedrive/_schema.py
@@ -78,9 +78,46 @@ class Organisation(PipedriveBaseModel):
 
         admins_from_hermes = {}
         if hasattr(self, 'support_person') and self.support_person:
+            if isinstance(self.support_person, int):
+                self.support_person = await Admin.get(id=self.support_person)
             admins_from_hermes['support_person_id'] = self.support_person.id
+
         if hasattr(self, 'bdr_person') and self.bdr_person:
+            if isinstance(self.bdr_person, int):
+                self.bdr_person = await Admin.get(id=self.bdr_person)
             admins_from_hermes['bdr_person_id'] = self.bdr_person.id
+
+        debug(admins_from_hermes)
+
+        return {
+            'pd_org_id': self.id,
+            'name': self.name,
+            'sales_person_id': self.admin.id,  # noqa: F821 - Added in a_validate
+            **_remove_nulls(**cf_data_from_hermes),
+            **_remove_nulls(**admins_from_hermes),
+        }
+
+    async def create_company_dict(self, custom_fields: list[CustomField]) -> dict:
+        cf_data_from_hermes = {
+            c.hermes_field_name: getattr(self, c.machine_name)
+            for c in custom_fields
+            if c.hermes_field_name and c.field_type != CustomField.TYPE_FK_FIELD
+        }
+
+        admins_from_hermes = {}
+        if hasattr(self, 'support_person') and self.support_person:
+            if isinstance(self.support_person, int):
+                self.support_person = await Admin.get(id=self.support_person)
+                admins_from_hermes['support_person'] = self.support_person
+            # admins_from_hermes['support_person_id'] = self.support_person.id
+
+        if hasattr(self, 'bdr_person') and self.bdr_person:
+            if isinstance(self.bdr_person, int):
+                self.bdr_person = await Admin.get(id=self.bdr_person)
+                admins_from_hermes['bdr_person'] = self.bdr_person
+            # admins_from_hermes['bdr_person_id'] = self.bdr_person.id
+
+        debug(admins_from_hermes)
 
         return {
             'pd_org_id': self.id,

--- a/app/pipedrive/_schema.py
+++ b/app/pipedrive/_schema.py
@@ -87,38 +87,6 @@ class Organisation(PipedriveBaseModel):
                 self.bdr_person = await Admin.get(id=self.bdr_person)
             admins_from_hermes['bdr_person_id'] = self.bdr_person.id
 
-        debug(admins_from_hermes)
-
-        return {
-            'pd_org_id': self.id,
-            'name': self.name,
-            'sales_person_id': self.admin.id,  # noqa: F821 - Added in a_validate
-            **_remove_nulls(**cf_data_from_hermes),
-            **_remove_nulls(**admins_from_hermes),
-        }
-
-    async def create_company_dict(self, custom_fields: list[CustomField]) -> dict:
-        cf_data_from_hermes = {
-            c.hermes_field_name: getattr(self, c.machine_name)
-            for c in custom_fields
-            if c.hermes_field_name and c.field_type != CustomField.TYPE_FK_FIELD
-        }
-
-        admins_from_hermes = {}
-        if hasattr(self, 'support_person') and self.support_person:
-            if isinstance(self.support_person, int):
-                self.support_person = await Admin.get(id=self.support_person)
-                admins_from_hermes['support_person'] = self.support_person
-            # admins_from_hermes['support_person_id'] = self.support_person.id
-
-        if hasattr(self, 'bdr_person') and self.bdr_person:
-            if isinstance(self.bdr_person, int):
-                self.bdr_person = await Admin.get(id=self.bdr_person)
-                admins_from_hermes['bdr_person'] = self.bdr_person
-            # admins_from_hermes['bdr_person_id'] = self.bdr_person.id
-
-        debug(admins_from_hermes)
-
         return {
             'pd_org_id': self.id,
             'name': self.name,

--- a/app/pipedrive/_schema.py
+++ b/app/pipedrive/_schema.py
@@ -75,13 +75,19 @@ class Organisation(PipedriveBaseModel):
             for c in custom_fields
             if c.hermes_field_name and c.field_type != CustomField.TYPE_FK_FIELD
         }
+
+        admins_from_hermes = {}
+        if hasattr(self, 'support_person') and self.support_person:
+            admins_from_hermes['support_person_id'] = self.support_person.id
+        if hasattr(self, 'bdr_person') and self.bdr_person:
+            admins_from_hermes['bdr_person_id'] = self.bdr_person.id
+
         return {
             'pd_org_id': self.id,
             'name': self.name,
             'sales_person_id': self.admin.id,  # noqa: F821 - Added in a_validate
-            'support_person_id': self.support_person.id,
-            'bdr_person_id': self.bdr_person.id,
             **_remove_nulls(**cf_data_from_hermes),
+            **_remove_nulls(**admins_from_hermes),
         }
 
 

--- a/app/pipedrive/views.py
+++ b/app/pipedrive/views.py
@@ -38,6 +38,7 @@ async def callback(event: PipedriveEvent, tasks: BackgroundTasks):
     elif event.meta.object == 'person':
         await _process_pd_person(event.current, event.previous)
     elif event.meta.object == 'organization':
+        debug('Processing organization')
         company = await _process_pd_organisation(event.current, event.previous)
         if company and company.tc2_agency_id:
             # We only update the client if the deal has a company with a tc2_agency_id

--- a/app/pipedrive/views.py
+++ b/app/pipedrive/views.py
@@ -45,7 +45,6 @@ async def callback(event: dict, tasks: BackgroundTasks):
 
     event_data = await prepare_event_data(event)
     event_instance = PipedriveEvent(**event_data)
-
     event_instance.current and await event_instance.current.a_validate()
     event_instance.previous and await event_instance.previous.a_validate()
 

--- a/app/pipedrive/views.py
+++ b/app/pipedrive/views.py
@@ -38,7 +38,6 @@ async def callback(event: PipedriveEvent, tasks: BackgroundTasks):
     elif event.meta.object == 'person':
         await _process_pd_person(event.current, event.previous)
     elif event.meta.object == 'organization':
-        debug('Processing organization')
         company = await _process_pd_organisation(event.current, event.previous)
         if company and company.tc2_agency_id:
             # We only update the client if the deal has a company with a tc2_agency_id

--- a/app/tc2/tasks.py
+++ b/app/tc2/tasks.py
@@ -14,7 +14,6 @@ async def update_client_from_company(company: Company):
     When an Organisation or Deal changes in Pipedrive, we want to update the Cligency obj in TC, we also update the
     admins associated with the client.
     """
-    debug(company.__dict__)
     if cligency_id := company.tc2_cligency_id:
         tc_client = TCClient(**await tc2_request(f'clients/{cligency_id}/'))
         extra_attrs = {ea.machine_name: ea.value for ea in tc_client.extra_attrs}

--- a/app/tc2/tasks.py
+++ b/app/tc2/tasks.py
@@ -24,7 +24,7 @@ async def update_client_from_company(company: Company):
                 pipedrive_deal_stage=(await deal.stage).name, pipedrive_pipeline=(await deal.pipeline).name
             )
         custom_fields = await CustomField.filter(
-            linked_object_type=Company.__name__, tc2_machine_name__isnull=False
+            linked_object_type=Company.__name__,  tc2_machine_name__not=''
         ).prefetch_related(Prefetch('values', queryset=CustomFieldValue.filter(company=company)))
         for cf in custom_fields:
             if cf.hermes_field_name:

--- a/app/tc2/tasks.py
+++ b/app/tc2/tasks.py
@@ -45,14 +45,11 @@ async def update_client_from_company(company: Company):
 
         if company.sales_person:
             sales_person = await company.sales_person
-            debug(sales_person.__dict__)
             client_data['sales_person'] = sales_person.tc2_admin_id
 
         client_data.pop('associated_admin_id', None)
         client_data.pop('bdr_person_id', None)
         client_data.pop('sales_person_id', None)
-
-        debug(client_data)
 
         with logfire.span('POST to TC2 clients/'):
             await tc2_request('clients/', method='POST', data=client_data)

--- a/app/tc2/tasks.py
+++ b/app/tc2/tasks.py
@@ -14,6 +14,7 @@ async def update_client_from_company(company: Company):
     When an Organisation or Deal changes in Pipedrive, we want to update the Cligency obj in TC, we also update the
     admins associated with the client.
     """
+    debug(company.__dict__)
     if cligency_id := company.tc2_cligency_id:
         tc_client = TCClient(**await tc2_request(f'clients/{cligency_id}/'))
         extra_attrs = {ea.machine_name: ea.value for ea in tc_client.extra_attrs}

--- a/app/tc2/tasks.py
+++ b/app/tc2/tasks.py
@@ -45,7 +45,14 @@ async def update_client_from_company(company: Company):
 
         if company.sales_person:
             sales_person = await company.sales_person
+            debug(sales_person.__dict__)
             client_data['sales_person'] = sales_person.tc2_admin_id
+
+        client_data.pop('associated_admin_id', None)
+        client_data.pop('bdr_person_id', None)
+        client_data.pop('sales_person_id', None)
+
+        debug(client_data)
 
         with logfire.span('POST to TC2 clients/'):
             await tc2_request('clients/', method='POST', data=client_data)

--- a/app/tc2/tasks.py
+++ b/app/tc2/tasks.py
@@ -11,7 +11,8 @@ from app.tc2.api import tc2_request
 
 async def update_client_from_company(company: Company):
     """
-    When an Organisation or Deal changes in Pipedrive, we want to update the Cligency obj in TC.
+    When an Organisation or Deal changes in Pipedrive, we want to update the Cligency obj in TC, we also update the
+    admins associated with the client.
     """
     if cligency_id := company.tc2_cligency_id:
         tc_client = TCClient(**await tc2_request(f'clients/{cligency_id}/'))
@@ -33,6 +34,19 @@ async def update_client_from_company(company: Company):
             extra_attrs[cf.tc2_machine_name] = val
         client_data = tc_client.model_dump()
         client_data['extra_attrs'] = extra_attrs
+
+        if company.support_person:
+            support_person = await company.support_person
+            client_data['associated_admin'] = support_person.tc2_admin_id
+
+        if company.bdr_person:
+            bdr_person = await company.bdr_person
+            client_data['bdr_person'] = bdr_person.tc2_admin_id
+
+        if company.sales_person:
+            sales_person = await company.sales_person
+            client_data['sales_person'] = sales_person.tc2_admin_id
+
         with logfire.span('POST to TC2 clients/'):
             await tc2_request('clients/', method='POST', data=client_data)
 

--- a/app/tc2/tasks.py
+++ b/app/tc2/tasks.py
@@ -24,7 +24,7 @@ async def update_client_from_company(company: Company):
                 pipedrive_deal_stage=(await deal.stage).name, pipedrive_pipeline=(await deal.pipeline).name
             )
         custom_fields = await CustomField.filter(
-            linked_object_type=Company.__name__,  tc2_machine_name__not=''
+            linked_object_type=Company.__name__, tc2_machine_name__not=''
         ).prefetch_related(Prefetch('values', queryset=CustomFieldValue.filter(company=company)))
         for cf in custom_fields:
             if cf.hermes_field_name:

--- a/migrations/models/4_20240510112642_update.py
+++ b/migrations/models/4_20240510112642_update.py
@@ -1,0 +1,21 @@
+from tortoise import BaseDBAsyncClient
+
+
+async def upgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        ALTER TABLE "admin" ADD "sells_row" BOOL NOT NULL  DEFAULT False;
+        ALTER TABLE "admin" ADD "sells_us" BOOL NOT NULL  DEFAULT False;
+        ALTER TABLE "admin" ADD "sells_gb" BOOL NOT NULL  DEFAULT False;
+        ALTER TABLE "admin" ADD "sells_au" BOOL NOT NULL  DEFAULT False;
+        ALTER TABLE "admin" ADD "sells_eu" BOOL NOT NULL  DEFAULT False;
+        ALTER TABLE "admin" ADD "sells_ca" BOOL NOT NULL  DEFAULT False;"""
+
+
+async def downgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        ALTER TABLE "admin" DROP COLUMN "sells_row";
+        ALTER TABLE "admin" DROP COLUMN "sells_us";
+        ALTER TABLE "admin" DROP COLUMN "sells_gb";
+        ALTER TABLE "admin" DROP COLUMN "sells_au";
+        ALTER TABLE "admin" DROP COLUMN "sells_eu";
+        ALTER TABLE "admin" DROP COLUMN "sells_ca";"""

--- a/scripts/inital_db.py
+++ b/scripts/inital_db.py
@@ -1,4 +1,5 @@
 from tortoise import Tortoise, run_async
+
 from app.models import Admin, Company, Config, Contact, CustomField, Deal, Pipeline, Stage
 from app.utils import logger
 

--- a/tests/test_callbooker.py
+++ b/tests/test_callbooker.py
@@ -160,8 +160,8 @@ class MeetingBookingTestCase(HermesTestCase):
         assert company.website == 'https://junes.com'
         assert company.country == 'GB'
         assert company.estimated_income == '1000'
-        assert not company.support_person_id
-        assert not company.bdr_person_id
+        assert not company.support_person
+        assert not company.bdr_person
         assert await company.sales_person == sales_person
 
         contact = await Contact.get()
@@ -205,9 +205,9 @@ class MeetingBookingTestCase(HermesTestCase):
         assert company.name == 'Julies Ltd'
         assert company.website == 'https://junes.com'
         assert company.country == 'GB'
-        assert not company.support_person_id
+        assert not company.support_person
         assert await company.sales_person == sales_person
-        assert not company.bdr_person_id
+        assert not company.bdr_person
 
         contact = await Contact.get()
         assert contact.first_name == 'Brain'
@@ -252,8 +252,8 @@ class MeetingBookingTestCase(HermesTestCase):
         assert company.name == 'Julies Ltd'
         assert company.website == 'https://junes.com'
         assert company.country == 'GB'
-        assert not company.support_person_id
-        assert not company.bdr_person_id
+        assert not company.support_person
+        assert not company.bdr_person
         assert await company.sales_person == sales_person
 
         contact = await Contact.get()
@@ -300,8 +300,8 @@ class MeetingBookingTestCase(HermesTestCase):
         assert company.name == 'Julies Ltd'
         assert company.website == 'https://junes.com'
         assert company.country == 'GB'
-        assert not company.support_person_id
-        assert not company.bdr_person_id
+        assert not company.support_person
+        assert not company.bdr_person
         assert await company.sales_person == sales_person
 
         contact = await Contact.get()
@@ -346,8 +346,8 @@ class MeetingBookingTestCase(HermesTestCase):
         assert company.name == 'Junes Ltd'
         assert company.website == 'https://junes.com'
         assert company.country == 'GB'
-        assert not company.support_person_id
-        assert not company.bdr_person_id
+        assert not company.support_person
+        assert not company.bdr_person
 
         contact = await Contact.get()
         assert contact.first_name == 'B'
@@ -393,8 +393,8 @@ class MeetingBookingTestCase(HermesTestCase):
         assert company.name == 'Julies Ltd'
         assert company.website == 'https://junes.com'
         assert company.country == 'GB'
-        assert not company.support_person_id
-        assert not company.bdr_person_id
+        assert not company.support_person
+        assert not company.bdr_person
 
         contact = await Contact.get()
         assert contact.first_name == 'B'
@@ -494,8 +494,8 @@ class MeetingBookingTestCase(HermesTestCase):
         assert company.name == 'Julies Ltd'
         assert company.website == 'https://junes.com'
         assert company.country == 'GB'
-        assert not company.support_person_id
-        assert not company.bdr_person_id
+        assert not company.support_person
+        assert not company.bdr_person
 
         contact = await Contact.get()
         assert contact.first_name == 'B'

--- a/tests/test_combined.py
+++ b/tests/test_combined.py
@@ -307,3 +307,5 @@ class TestMultipleServices(HermesTestCase):
         assert company.name == 'MyTutors'
         assert company.bdr_person_id == bdr_person.id
         assert company.sales_person_id == sales_admin.id
+
+    # lets write a test which has a company setup in pipedrive and tc2 and hermes, then lets mock a a webhook from pipedrive updating the bdr person and check company.bdr_person is updated and that the bdr person updated

--- a/tests/test_combined.py
+++ b/tests/test_combined.py
@@ -309,7 +309,6 @@ class TestMultipleServices(HermesTestCase):
         assert company.bdr_person_id == bdr_person.id
         assert company.sales_person_id == sales_admin.id
 
-    # lets write a test which has a company setup in pipedrive and tc2 and hermes, then lets mock a a webhook from pipedrive updating the bdr person and check company.bdr_person is updated and that the bdr person updated
     @mock.patch('app.tc2.api.session.request')
     @mock.patch('app.pipedrive.api.session.request')
     async def test_tc2_cb_create_company_create_org_update_org(self, mock_pd_request, mock_tc2_get):
@@ -355,7 +354,6 @@ class TestMultipleServices(HermesTestCase):
         assert not company.bdr_person
         assert await company.support_person == await company.sales_person == admin
 
-        # check that pipedrive has the correct data
         assert self.pipedrive.db['organizations'] == {
             1: {
                 'id': 1,

--- a/tests/test_hermes.py
+++ b/tests/test_hermes.py
@@ -6,7 +6,7 @@ class SalesPersonDeciderTestCase(HermesTestCase):
     async def asyncSetUp(self):
         await super().asyncSetUp()
         self.url = '/choose-roundrobin/sales/'
-        sp_kwargs = {'is_sales_person': True, 'sells_payg': True, 'sells_startup': True}
+        sp_kwargs = {'is_sales_person': True, 'sells_payg': True, 'sells_startup': True, 'sells_gb': True}
         self.admin_1 = await Admin.create(last_name='1', username='admin_1@example.com', tc2_admin_id=10, **sp_kwargs)
         self.admin_2 = await Admin.create(last_name='2', username='admin_2@example.com', tc2_admin_id=20, **sp_kwargs)
         self.admin_3 = await Admin.create(last_name='3', username='admin_3@example.com', tc2_admin_id=30, **sp_kwargs)
@@ -15,11 +15,57 @@ class SalesPersonDeciderTestCase(HermesTestCase):
             username='enterprise@example.com',
             is_sales_person=True,
             sells_enterprise=True,
+            sells_gb=True,
+            sells_us=True,
+            sells_au=True,
+            sells_ca=True,
+            sells_eu=True,
+            sells_row=True,
             tc2_admin_id=40,
+        )
+        self.admin_payg_us = await Admin.create(
+            last_name='us',
+            username='us-payg@example.com',
+            is_sales_person=True,
+            sells_payg=True,
+            sells_us=True,
+            tc2_admin_id=50,
+        )
+        self.admin_payg_ca = await Admin.create(
+            last_name='ca',
+            username='ca-payg@example.com',
+            is_sales_person=True,
+            sells_payg=True,
+            sells_ca=True,
+            tc2_admin_id=60,
+        )
+        self.admin_startup_eu = await Admin.create(
+            last_name='eu',
+            username='eu-startup@example.com',
+            is_sales_person=True,
+            sells_startup=True,
+            sells_eu=True,
+            tc2_admin_id=70,
+        )
+        self.admin_startup_au = await Admin.create(
+            last_name='au',
+            username='au-startup@example.com',
+            is_sales_person=True,
+            sells_startup=True,
+            sells_au=True,
+            tc2_admin_id=80,
+        )
+        self.admin_startup_row = await Admin.create(
+            last_name='row',
+            username='row-startup@example.com',
+            is_sales_person=True,
+            sells_startup=True,
+            sells_row=True,
+            tc2_admin_id=90,
         )
 
     async def test_no_companies(self):
-        r = await self.client.get(self.url + '?plan=payg')
+        r = await self.client.get(self.url + '?plan=payg&country_code=GB')
         assert r.status_code == 200
         assert r.json() == {
             'username': 'admin_1@example.com',
@@ -35,13 +81,164 @@ class SalesPersonDeciderTestCase(HermesTestCase):
             'sells_payg': True,
             'sells_startup': True,
             'sells_enterprise': False,
+            'sells_gb': True,
+            'sells_us': False,
+            'sells_au': False,
+            'sells_ca': False,
+            'sells_eu': False,
+            'sells_row': False,
+        }
+        r = await self.client.get(self.url + '?plan=payg&country_code=US')
+        assert r.json() == {
+            'username': 'us-payg@example.com',
+            'id': self.admin_payg_us.id,
+            'tc2_admin_id': 50,
+            'pd_owner_id': None,
+            'first_name': '',
+            'last_name': 'us',
+            'timezone': 'Europe/London',
+            'is_sales_person': True,
+            'is_support_person': False,
+            'is_bdr_person': False,
+            'sells_payg': True,
+            'sells_startup': False,
+            'sells_enterprise': False,
+            'sells_gb': False,
+            'sells_us': True,
+            'sells_au': False,
+            'sells_ca': False,
+            'sells_eu': False,
+            'sells_row': False,
+        }
+        r = await self.client.get(self.url + '?plan=payg&country_code=CA')
+        assert r.json() == {
+            'username': 'ca-payg@example.com',
+            'id': self.admin_payg_ca.id,
+            'tc2_admin_id': 60,
+            'pd_owner_id': None,
+            'first_name': '',
+            'last_name': 'ca',
+            'timezone': 'Europe/London',
+            'is_sales_person': True,
+            'is_support_person': False,
+            'is_bdr_person': False,
+            'sells_payg': True,
+            'sells_startup': False,
+            'sells_enterprise': False,
+            'sells_gb': False,
+            'sells_us': False,
+            'sells_au': False,
+            'sells_ca': True,
+            'sells_eu': False,
+            'sells_row': False,
+        }
+        r = await self.client.get(self.url + '?plan=startup&country_code=FR')
+        assert r.json() == {
+            'username': 'eu-startup@example.com',
+            'id': self.admin_startup_eu.id,
+            'tc2_admin_id': 70,
+            'pd_owner_id': None,
+            'first_name': '',
+            'last_name': 'eu',
+            'timezone': 'Europe/London',
+            'is_sales_person': True,
+            'is_support_person': False,
+            'is_bdr_person': False,
+            'sells_payg': False,
+            'sells_startup': True,
+            'sells_enterprise': False,
+            'sells_gb': False,
+            'sells_us': False,
+            'sells_au': False,
+            'sells_ca': False,
+            'sells_eu': True,
+            'sells_row': False,
+        }
+        r = await self.client.get(self.url + '?plan=startup&country_code=AU')
+        assert r.json() == {
+            'username': 'au-startup@example.com',
+            'id': self.admin_startup_au.id,
+            'tc2_admin_id': 80,
+            'pd_owner_id': None,
+            'first_name': '',
+            'last_name': 'au',
+            'timezone': 'Europe/London',
+            'is_sales_person': True,
+            'is_support_person': False,
+            'is_bdr_person': False,
+            'sells_payg': False,
+            'sells_startup': True,
+            'sells_enterprise': False,
+            'sells_gb': False,
+            'sells_us': False,
+            'sells_au': True,
+            'sells_ca': False,
+            'sells_eu': False,
+            'sells_row': False,
+        }
+        r = await self.client.get(self.url + '?plan=startup&country_code=JP')
+        assert r.json() == {
+            'username': 'row-startup@example.com',
+            'id': self.admin_startup_row.id,
+            'tc2_admin_id': 90,
+            'pd_owner_id': None,
+            'first_name': '',
+            'last_name': 'row',
+            'timezone': 'Europe/London',
+            'is_sales_person': True,
+            'is_support_person': False,
+            'is_bdr_person': False,
+            'sells_payg': False,
+            'sells_startup': True,
+            'sells_enterprise': False,
+            'sells_gb': False,
+            'sells_us': False,
+            'sells_au': False,
+            'sells_ca': False,
+            'sells_eu': False,
+            'sells_row': True,
+        }
+
+    async def test_no_companies_no_regional_admin(self):
+        admin = await Admin.all()
+        for a in admin:
+            a.sells_gb = False
+            a.sells_us = False
+            a.sells_au = False
+            a.sells_ca = False
+            a.sells_eu = False
+            a.sells_row = False
+            await a.save()
+
+        r = await self.client.get(self.url + '?plan=payg&country_code=GB')
+        assert r.status_code == 200
+        assert r.json() == {
+            'username': 'admin_1@example.com',
+            'id': self.admin_1.id,
+            'tc2_admin_id': 10,
+            'pd_owner_id': None,
+            'first_name': '',
+            'last_name': '1',
+            'timezone': 'Europe/London',
+            'is_sales_person': True,
+            'is_support_person': False,
+            'is_bdr_person': False,
+            'sells_payg': True,
+            'sells_startup': True,
+            'sells_enterprise': False,
+            'sells_gb': False,
+            'sells_us': False,
+            'sells_au': False,
+            'sells_ca': False,
+            'sells_eu': False,
+            'sells_row': False,
         }
 
     async def test_payg_round_robin(self):
         company = await Company.create(
             name='Junes Ltd', website='https://junes.com', country='GB', price_plan='payg', sales_person=self.admin_1
         )
-        r = await self.client.get(self.url + '?plan=payg')
+        r = await self.client.get(self.url + '?plan=payg&country_code=GB')
         assert r.status_code == 200
         assert r.json() == {
             'username': 'admin_2@example.com',
@@ -57,10 +254,16 @@ class SalesPersonDeciderTestCase(HermesTestCase):
             'sells_payg': True,
             'sells_startup': True,
             'sells_enterprise': False,
+            'sells_gb': True,
+            'sells_us': False,
+            'sells_au': False,
+            'sells_ca': False,
+            'sells_eu': False,
+            'sells_row': False,
         }
         company.sales_person = self.admin_2
         await company.save()
-        r = await self.client.get(self.url + '?plan=payg')
+        r = await self.client.get(self.url + '?plan=payg&country_code=GB')
         assert r.json() == {
             'username': 'admin_3@example.com',
             'id': self.admin_3.id,
@@ -75,10 +278,16 @@ class SalesPersonDeciderTestCase(HermesTestCase):
             'sells_payg': True,
             'sells_startup': True,
             'sells_enterprise': False,
+            'sells_gb': True,
+            'sells_us': False,
+            'sells_au': False,
+            'sells_ca': False,
+            'sells_eu': False,
+            'sells_row': False,
         }
         company.sales_person = self.admin_3
         await company.save()
-        r = await self.client.get(self.url + '?plan=payg')
+        r = await self.client.get(self.url + '?plan=payg&country_code=GB')
         assert r.json() == {
             'username': 'admin_1@example.com',
             'id': self.admin_1.id,
@@ -93,13 +302,19 @@ class SalesPersonDeciderTestCase(HermesTestCase):
             'sells_payg': True,
             'sells_startup': True,
             'sells_enterprise': False,
+            'sells_gb': True,
+            'sells_us': False,
+            'sells_au': False,
+            'sells_ca': False,
+            'sells_eu': False,
+            'sells_row': False,
         }
 
     async def test_startup(self):
         company = await Company.create(
             name='Junes Ltd', website='https://junes.com', country='GB', price_plan='startup', sales_person=self.admin_1
         )
-        r = await self.client.get(self.url + '?plan=startup')
+        r = await self.client.get(self.url + '?plan=startup&country_code=GB')
         assert r.status_code == 200
         assert r.json() == {
             'username': 'admin_2@example.com',
@@ -115,10 +330,16 @@ class SalesPersonDeciderTestCase(HermesTestCase):
             'sells_payg': True,
             'sells_startup': True,
             'sells_enterprise': False,
+            'sells_gb': True,
+            'sells_us': False,
+            'sells_au': False,
+            'sells_ca': False,
+            'sells_eu': False,
+            'sells_row': False,
         }
         company.sales_person = self.admin_2
         await company.save()
-        r = await self.client.get(self.url + '?plan=startup')
+        r = await self.client.get(self.url + '?plan=startup&country_code=GB')
         assert r.json() == {
             'username': 'admin_3@example.com',
             'id': self.admin_3.id,
@@ -133,10 +354,16 @@ class SalesPersonDeciderTestCase(HermesTestCase):
             'sells_payg': True,
             'sells_startup': True,
             'sells_enterprise': False,
+            'sells_gb': True,
+            'sells_us': False,
+            'sells_au': False,
+            'sells_ca': False,
+            'sells_eu': False,
+            'sells_row': False,
         }
         company.sales_person = self.admin_3
         await company.save()
-        r = await self.client.get(self.url + '?plan=startup')
+        r = await self.client.get(self.url + '?plan=startup&country_code=GB')
         assert r.json() == {
             'username': 'admin_1@example.com',
             'id': self.admin_1.id,
@@ -151,6 +378,12 @@ class SalesPersonDeciderTestCase(HermesTestCase):
             'sells_payg': True,
             'sells_startup': True,
             'sells_enterprise': False,
+            'sells_gb': True,
+            'sells_us': False,
+            'sells_au': False,
+            'sells_ca': False,
+            'sells_eu': False,
+            'sells_row': False,
         }
 
     async def test_enterprise(self):
@@ -161,7 +394,7 @@ class SalesPersonDeciderTestCase(HermesTestCase):
             price_plan='enterprise',
             sales_person=self.admin_1,
         )
-        r = await self.client.get(self.url + '?plan=enterprise')
+        r = await self.client.get(self.url + '?plan=enterprise&country_code=GB')
         assert r.status_code == 200
         assert r.json() == {
             'username': 'enterprise@example.com',
@@ -177,10 +410,16 @@ class SalesPersonDeciderTestCase(HermesTestCase):
             'sells_payg': False,
             'sells_startup': False,
             'sells_enterprise': True,
+            'sells_gb': True,
+            'sells_us': True,
+            'sells_au': True,
+            'sells_ca': True,
+            'sells_eu': True,
+            'sells_row': True,
         }
         company.sales_person = self.admin_enterprise
         await company.save()
-        r = await self.client.get(self.url + '?plan=enterprise')
+        r = await self.client.get(self.url + '?plan=enterprise&country_code=US')
         assert r.json() == {
             'username': 'enterprise@example.com',
             'id': self.admin_enterprise.id,
@@ -195,12 +434,22 @@ class SalesPersonDeciderTestCase(HermesTestCase):
             'sells_payg': False,
             'sells_startup': False,
             'sells_enterprise': True,
+            'sells_gb': True,
+            'sells_us': True,
+            'sells_au': True,
+            'sells_ca': True,
+            'sells_eu': True,
+            'sells_row': True,
         }
 
     async def test_invalid_plan(self):
-        r = await self.client.get(self.url + '?plan=foobar')
+        r = await self.client.get(self.url + '?plan=foobar&country_code=GB')
         assert r.status_code == 422
         assert r.json() == {'detail': 'Price plan must be one of "payg,startup,enterprise"'}
+
+    async def test_no_country_code(self):
+        r = await self.client.get(self.url + '?plan=payg')
+        assert r.status_code == 422
 
 
 class SupportPersonDeciderTestCase(HermesTestCase):
@@ -234,6 +483,12 @@ class SupportPersonDeciderTestCase(HermesTestCase):
             'sells_payg': False,
             'sells_startup': False,
             'sells_enterprise': False,
+            'sells_gb': False,
+            'sells_us': False,
+            'sells_au': False,
+            'sells_ca': False,
+            'sells_eu': False,
+            'sells_row': False,
         }
 
     async def test_support_round_robin(self):
@@ -260,6 +515,12 @@ class SupportPersonDeciderTestCase(HermesTestCase):
             'sells_payg': False,
             'sells_startup': False,
             'sells_enterprise': False,
+            'sells_gb': False,
+            'sells_us': False,
+            'sells_au': False,
+            'sells_ca': False,
+            'sells_eu': False,
+            'sells_row': False,
         }
         company.support_person = self.admin_2
         await company.save()
@@ -278,6 +539,12 @@ class SupportPersonDeciderTestCase(HermesTestCase):
             'sells_payg': False,
             'sells_startup': False,
             'sells_enterprise': False,
+            'sells_gb': False,
+            'sells_us': False,
+            'sells_au': False,
+            'sells_ca': False,
+            'sells_eu': False,
+            'sells_row': False,
         }
         company.support_person = self.admin_3
         await company.save()
@@ -296,6 +563,12 @@ class SupportPersonDeciderTestCase(HermesTestCase):
             'sells_payg': False,
             'sells_startup': False,
             'sells_enterprise': False,
+            'sells_gb': False,
+            'sells_us': False,
+            'sells_au': False,
+            'sells_ca': False,
+            'sells_eu': False,
+            'sells_row': False,
         }
 
 
@@ -370,6 +643,12 @@ class GetCompaniesTestCase(HermesTestCase):
                     'sells_payg': False,
                     'sells_startup': False,
                     'sells_enterprise': False,
+                    'sells_gb': False,
+                    'sells_us': False,
+                    'sells_au': False,
+                    'sells_ca': False,
+                    'sells_eu': False,
+                    'sells_row': False,
                     'deals': [],
                     'meetings': [],
                 },
@@ -425,6 +704,12 @@ class GetCompaniesTestCase(HermesTestCase):
                     'sells_payg': False,
                     'sells_startup': False,
                     'sells_enterprise': False,
+                    'sells_gb': False,
+                    'sells_us': False,
+                    'sells_au': False,
+                    'sells_ca': False,
+                    'sells_eu': False,
+                    'sells_row': False,
                     'deals': [],
                     'meetings': [],
                 },

--- a/tests/test_pipedrive.py
+++ b/tests/test_pipedrive.py
@@ -2062,6 +2062,46 @@ class PipedriveCallbackTestCase(HermesTestCase):
         await build_custom_field_schema()
 
     @mock.patch('app.pipedrive.api.session.request')
+    async def test_org_update_associated_custom_fk_field_error(self, mock_request):
+        admin = await Admin.create(
+            first_name='Steve',
+            last_name='Jobs',
+            username='climan@example.com',
+            is_sales_person=True,
+            tc2_admin_id=20,
+            pd_owner_id=99,
+        )
+
+        support_person_field = await CustomField.create(
+            linked_object_type='Company',
+            pd_field_id='123_support_person_id_456',
+            hermes_field_name='support_person',
+            name='Support Person ID',
+            field_type=CustomField.TYPE_FK_FIELD,
+        )
+
+        await build_custom_field_schema()
+        mock_request.side_effect = fake_pd_request(self.pipedrive)
+        company = await Company.create(name='Old test company', sales_person=self.admin)
+
+        await CustomFieldValue.create(custom_field=support_person_field, company=company, value=admin.id)
+
+        data = copy.deepcopy(basic_pd_org_data())
+        data[PDStatus.PREVIOUS] = copy.deepcopy(data[PDStatus.CURRENT])
+        data[PDStatus.PREVIOUS].update(hermes_id=company.id)
+        data[PDStatus.CURRENT].update(
+            **{
+                'name': 'New test company',
+                '123_support_person_id_456': 400,
+            }
+        )
+        r = await self.client.post(self.url, json=data)
+        assert r.status_code == 422  # valadation error
+
+        await support_person_field.delete()
+        await build_custom_field_schema()
+
+    @mock.patch('app.pipedrive.api.session.request')
     async def test_org_update_custom_field_val_deleted(self, mock_request):
         source_field = await CustomField.create(
             linked_object_type='Company',

--- a/tests/test_tc2.py
+++ b/tests/test_tc2.py
@@ -42,6 +42,12 @@ def _client_data():
             'last_name': 'Johnson',
             'email': 'brian@tc.com',
         },
+        'bdr_person': {
+            'id': 30,
+            'first_name': 'Brain',
+            'last_name': 'Johnson',
+            'email': 'brian@tc.com',
+        },
         'paid_recipients': [
             {
                 'id': 40,
@@ -677,6 +683,13 @@ def fake_tc2_request(fake_tc2: FakeTC2):
                 for id, obj_data in fake_tc2.db[obj_type].items()
                 if obj_data['user']['email'] == data['user']['email']
             )
+
+            admin_keys = ['sales_person', 'associated_admin', 'bdr_person']
+
+            for key in admin_keys:
+                data[key] = fake_tc2.db[obj_type][obj_id][key] if data.get(key) == fake_tc2.db[obj_type][obj_id][key][
+                    'id'] else None
+
             fake_tc2.db[obj_type][obj_id] = data
             return MockResponse(200, fake_tc2.db[obj_type][obj_id])
 
@@ -723,9 +736,24 @@ class TC2TasksTestCase(HermesTestCase):
                     'last_name': 'Booth',
                 },
                 'status': 'live',
-                'sales_person_id': 30,
-                'associated_admin_id': 30,
-                'bdr_person_id': None,
+                'sales_person': {
+                    'id': 30,
+                    'first_name': 'Brain',
+                    'last_name': 'Johnson',
+                    'email': 'brian@tc.com',
+                },
+                'associated_admin': {
+                    'id': 30,
+                    'first_name': 'Brain',
+                    'last_name': 'Johnson',
+                    'email': 'brian@tc.com',
+                },
+                'bdr_person': {
+                    'id': 30,
+                    'first_name': 'Brain',
+                    'last_name': 'Johnson',
+                    'email': 'brian@tc.com',
+                },
                 'paid_recipients': [
                     {
                         'email': 'mary@booth.com',
@@ -743,7 +771,8 @@ class TC2TasksTestCase(HermesTestCase):
     @mock.patch('app.tc2.api.session.request')
     async def test_update_cligency_with_deal(self, mock_request):
         mock_request.side_effect = fake_tc2_request(self.tc2)
-        admin = await Admin.create(pd_owner_id=10, username='testing@example.com', is_sales_person=True)
+        admin = await Admin.create(pd_owner_id=10, username='testing@example.com', is_sales_person=True,
+                                   tc2_admin_id=30)
         company = await Company.create(
             name='Test company', pd_org_id=20, tc2_cligency_id=10, sales_person=admin, price_plan=Company.PP_PAYG
         )
@@ -767,9 +796,14 @@ class TC2TasksTestCase(HermesTestCase):
                     'last_name': 'Booth',
                 },
                 'status': 'live',
-                'sales_person_id': 30,
-                'associated_admin_id': 30,
-                'bdr_person_id': None,
+                'sales_person': {
+                    'id': 30,
+                    'first_name': 'Brain',
+                    'last_name': 'Johnson',
+                    'email': 'brian@tc.com',
+                },
+                'associated_admin': None,
+                'bdr_person': None,
                 'paid_recipients': [
                     {
                         'email': 'mary@booth.com',
@@ -818,6 +852,7 @@ class TC2TasksTestCase(HermesTestCase):
                     'last_name': 'Booth',
                 },
                 'status': 'live',
+                'sales_person': None,
                 'sales_person_id': 30,
                 'associated_admin_id': 30,
                 'bdr_person_id': None,
@@ -876,6 +911,7 @@ class TC2TasksTestCase(HermesTestCase):
                     'last_name': 'Booth',
                 },
                 'status': 'live',
+                'sales_person': None,
                 'sales_person_id': 30,
                 'associated_admin_id': 30,
                 'bdr_person_id': None,


### PR DESCRIPTION
Close #238 

Fix Updating BDR, Sales and support admins in pipedrive update hermes, which in turn update TC2 accordingly


also improved the readme


### Testing steps

- Follow updated readme to setup pipedrive, hermes and TC2 setup
- Signup as new agency on TC2
- in Pipedrive modify the `support_person_id`﻿ and `bdr_person_id`
- check in Hermes that both IDs are updated accordingly
- check in TC2 Profile > Client Mangers > BDR Person, Client Manger and Sales Person are all updated accordingly
