### PR TITLE
Handle PD event status obj is None

### DIFF
--- a/app/pipedrive/views.py
+++ b/app/pipedrive/views.py
@@ -23,9 +23,10 @@ async def prepare_event_data(event_data: dict) -> dict:
     """
     hermes_id_cf_fields = await CustomField.filter(machine_name='hermes_id').values_list('pd_field_id', flat=True)
     for hermes_id_pd_field_id in hermes_id_cf_fields:
-        for state in [PDStatus.PREVIOUS, PDStatus.CURRENT]:
+        for state in [PDStatus.PREVIOUS.value, PDStatus.CURRENT.value]:
             if (
                 state in event_data
+                and event_data[state]
                 and hermes_id_pd_field_id in event_data[state]
                 and isinstance(event_data[state][hermes_id_pd_field_id], str)
             ):
@@ -42,7 +43,7 @@ async def callback(event: dict, tasks: BackgroundTasks):
     Processes a Pipedrive event. If a Deal is updated then we run a background task to update the cligency in Pipedrive
     TODO: This has 0 security, we should add some.
     """
-
+    debug(event)
     event_data = await prepare_event_data(event)
     event_instance = PipedriveEvent(**event_data)
 

--- a/app/pipedrive/views.py
+++ b/app/pipedrive/views.py
@@ -25,7 +25,7 @@ async def prepare_event_data(event_data: dict) -> dict:
     for hermes_id_pd_field_id in hermes_id_cf_fields:
         for state in [PDStatus.PREVIOUS.value, PDStatus.CURRENT.value]:
             if (
-                event_data.get('state')
+                event_data.get(state)
                 and hermes_id_pd_field_id in event_data[state]
                 and isinstance(event_data[state][hermes_id_pd_field_id], str)
             ):

--- a/app/pipedrive/views.py
+++ b/app/pipedrive/views.py
@@ -43,7 +43,6 @@ async def callback(event: dict, tasks: BackgroundTasks):
     Processes a Pipedrive event. If a Deal is updated then we run a background task to update the cligency in Pipedrive
     TODO: This has 0 security, we should add some.
     """
-    debug(event)
     event_data = await prepare_event_data(event)
     event_instance = PipedriveEvent(**event_data)
 

--- a/app/pipedrive/views.py
+++ b/app/pipedrive/views.py
@@ -25,8 +25,7 @@ async def prepare_event_data(event_data: dict) -> dict:
     for hermes_id_pd_field_id in hermes_id_cf_fields:
         for state in [PDStatus.PREVIOUS.value, PDStatus.CURRENT.value]:
             if (
-                state in event_data
-                and event_data[state]
+                event_data.get('state')
                 and hermes_id_pd_field_id in event_data[state]
                 and isinstance(event_data[state][hermes_id_pd_field_id], str)
             ):

--- a/tests/test_pipedrive.py
+++ b/tests/test_pipedrive.py
@@ -1566,7 +1566,7 @@ def basic_pd_org_data():
         'matches_filters': {PDStatus.CURRENT: []},
         'meta': {'action': 'updated', 'object': 'organization'},
         PDStatus.CURRENT: {'owner_id': 10, 'id': 20, 'name': 'Test company', 'address_country': None},
-        PDStatus.PREVIOUS: {},
+        PDStatus.PREVIOUS: None,
         'event': 'updated.organization',
     }
 
@@ -1605,7 +1605,7 @@ def basic_pd_deal_data():
             'pipeline_id': 60,
             'user_id': 10,
         },
-        PDStatus.PREVIOUS: {},
+        PDStatus.PREVIOUS: None,
         'event': 'updated.deal',
     }
 


### PR DESCRIPTION


in `prepare_event_data`﻿ I was previously iterating through the pervious and current objects, but first was checking if that status object exists in the event, however in real world pd response the statuses will always exist but will be `None`



