### PR TITLE
add logic to has signed up and has booked call

### DIFF
--- a/app/callbooker/_process.py
+++ b/app/callbooker/_process.py
@@ -93,6 +93,9 @@ async def get_or_create_contact_company(event: CBSalesCall) -> tuple[Company, Co
         await company.save()
     contact = contact or await get_or_create_contact(company, event)
     app_logger.info(f'Got company {company} and contact {contact} from {event}')
+
+    company.has_booked_call = True
+    await company.save()
     return company, contact
 
 

--- a/app/tc2/_process.py
+++ b/app/tc2/_process.py
@@ -24,6 +24,10 @@ async def _create_or_update_company(tc2_client: TCClient) -> tuple[bool, Company
         raise ValidationError('Company must have a sales_person, Please add one in TC2')
 
     company, created = await Company.get_or_create(tc2_agency_id=company_id, defaults=company_data)
+
+    company.has_signed_up = True
+    await company.save()
+
     if not created:
         company = await company.update_from_dict(company_data)
         await company.save()

--- a/tests/test_callbooker.py
+++ b/tests/test_callbooker.py
@@ -159,6 +159,7 @@ class MeetingBookingTestCase(HermesTestCase):
         assert company.website == 'https://junes.com'
         assert company.country == 'GB'
         assert company.estimated_income == '1000'
+        assert company.has_booked_call
         assert not company.support_person_id
         assert not company.bdr_person_id
         assert await company.sales_person == sales_person
@@ -204,6 +205,7 @@ class MeetingBookingTestCase(HermesTestCase):
         assert company.name == 'Julies Ltd'
         assert company.website == 'https://junes.com'
         assert company.country == 'GB'
+        assert company.has_booked_call
         assert not company.support_person_id
         assert await company.sales_person == sales_person
         assert not company.bdr_person_id
@@ -251,6 +253,7 @@ class MeetingBookingTestCase(HermesTestCase):
         assert company.name == 'Julies Ltd'
         assert company.website == 'https://junes.com'
         assert company.country == 'GB'
+        assert company.has_booked_call
         assert not company.support_person_id
         assert not company.bdr_person_id
         assert await company.sales_person == sales_person
@@ -299,6 +302,7 @@ class MeetingBookingTestCase(HermesTestCase):
         assert company.name == 'Julies Ltd'
         assert company.website == 'https://junes.com'
         assert company.country == 'GB'
+        assert company.has_booked_call
         assert not company.support_person_id
         assert not company.bdr_person_id
         assert await company.sales_person == sales_person
@@ -345,6 +349,7 @@ class MeetingBookingTestCase(HermesTestCase):
         assert company.name == 'Junes Ltd'
         assert company.website == 'https://junes.com'
         assert company.country == 'GB'
+        assert company.has_booked_call
         assert not company.support_person_id
         assert not company.bdr_person_id
 
@@ -392,6 +397,7 @@ class MeetingBookingTestCase(HermesTestCase):
         assert company.name == 'Julies Ltd'
         assert company.website == 'https://junes.com'
         assert company.country == 'GB'
+        assert company.has_booked_call
         assert not company.support_person_id
         assert not company.bdr_person_id
 
@@ -433,6 +439,7 @@ class MeetingBookingTestCase(HermesTestCase):
         company = await Company.get()
         assert not company.tc2_cligency_id
         assert company.name == 'Junes Ltd'
+        assert company.has_booked_call
         assert (await company.bdr_person) == bdr_person
         assert (await company.sales_person) == sales_person
 
@@ -493,6 +500,7 @@ class MeetingBookingTestCase(HermesTestCase):
         assert company.name == 'Julies Ltd'
         assert company.website == 'https://junes.com'
         assert company.country == 'GB'
+        assert company.has_booked_call
         assert not company.support_person_id
         assert not company.bdr_person_id
 

--- a/tests/test_tc2.py
+++ b/tests/test_tc2.py
@@ -227,6 +227,8 @@ class TC2CallbackTestCase(HermesTestCase):
         assert company.tc2_status == 'trial'
         assert company.country == 'GB'
         assert company.paid_invoice_count == 0
+        assert company.has_signed_up
+        assert not company.has_booked_call
         assert await company.support_person == await company.sales_person == admin
 
         assert not company.estimated_income
@@ -299,6 +301,8 @@ class TC2CallbackTestCase(HermesTestCase):
         assert company.tc2_status == 'active'
         assert company.country == 'GB'
         assert company.paid_invoice_count == 2
+        assert company.has_signed_up
+        assert not company.has_booked_call
         assert await company.sales_person == admin
         assert not await company.support_person
 
@@ -339,6 +343,8 @@ class TC2CallbackTestCase(HermesTestCase):
         assert company.tc2_status == 'active'
         assert company.country == 'GB'
         assert company.paid_invoice_count == 2
+        assert company.has_signed_up
+        assert not company.has_booked_call
         assert not await company.support_person
 
         assert await company.sales_person == admin


### PR DESCRIPTION
Close #130﻿


Now when you signup / book a call the values

`has_signed_up`

and

`has_booked_call`

are set


### Testing

- Setup
- sign up from tc
- see `has signed up` is true
- book a call
- see `has booked call` is true