### PR TITLE
Create patch.py + write patch to update TC2 Cligencies with sales and BDR person

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,3 +366,16 @@ Create Meta Admins for the sales and support teams in TC2, and heremes, ensuring
 python patch.py <patch_name>
 ```
 
+## Shell
+
+tortoise-orm has a shell command that can be used to interact with the database.
+
+first install [tortoise-cli](https://github.com/tortoise/tortoise-cli)
+
+to run the shell, use the following command inside your hermes virtual environment:
+```
+tortoise-cli shell
+```
+
+hint1: you will need to import the models you want to use in the shell, i.e `from app.models import *`
+hint2: you can use the `await` keyword to run async functions in the shell, i.e `await Company.all()`

--- a/README.md
+++ b/README.md
@@ -353,4 +353,16 @@ More details can be found in the aerich docs.
 
 ## Deploying to Heroku  
 Create Meta Admins for the sales and support teams in TC2, and heremes, ensuring their tc2_admin_id matches the one in hermes. 
-  
+
+
+## Writing a Patch
+
+- In the patch.py file, create a new function that will be your patch.
+- The function needs to be made between the # Start of patch commands and # End of patch commands.
+- The function needs to have the @command decorator.
+
+#### Running a Patch
+```
+python patch.py <patch_name>
+```
+

--- a/patch.py
+++ b/patch.py
@@ -1,0 +1,66 @@
+import asyncio
+import os
+os.environ.setdefault('LOGFIRE_IGNORE_NO_CONFIG', '1')
+
+from datetime import datetime
+import click
+
+from app.main import TORTOISE_ORM
+from app.tc2.tasks import update_client_from_company
+from tortoise.expressions import Q
+from tortoise import Tortoise
+from app.models import Company
+import logfire
+
+async def init():
+    # Initialize Tortoise ORM
+    await Tortoise.init(config=TORTOISE_ORM)
+    await Tortoise.generate_schemas()
+
+commands = []
+
+def command(func):
+    commands.append(func)
+    return func
+
+# Start of patch commands
+
+@command
+async def send_companies_with_bdr_or_sales_to_tc2():
+    """
+    This patch sends companies with a BDR or Sales person to TC2.
+    """
+    print('Sending companies with BDR or Sales person to TC2')
+
+    companies = await Company.filter(
+        Q(sales_person=None) | Q(bdr_person=None)
+    )
+
+    print(f'Found {len(companies)} companies with BDR or Sales person')
+    for company in companies:
+        try:
+            await update_client_from_company(company)
+        except Exception as e:
+            print(f'Error updating company {company.id}: {e}')
+
+
+# End of patch commands
+
+@click.command()
+@click.argument('command', type=click.Choice([c.__name__ for c in commands]))
+def patch(command):
+    asyncio.run(main(command))
+
+async def main(command):
+    await init()
+
+    command_lookup = {c.__name__: c for c in commands}
+
+    start = datetime.now()
+    with logfire.span('patch.py {command=}', command=command):
+        await command_lookup[command]()
+
+    print(f'Patch took {(datetime.now() - start).total_seconds():0.2f}s')
+
+if __name__ == '__main__':
+    patch()


### PR DESCRIPTION
### Technical Description
Created a patch.py file

Created a patch to get all the companies without a bdr_person_id or sales_person_id, fetch their most up to date data in pd, to update the Company then send a webhook to TC2 to update the associated Cligencies

### Testing
- setup pipedrive and hermes and TC2
- Create a BDR admin in TC2, Hermes and Pipedrive (user)
- Sign up on tc2 `start/1` this will create the company in hermes and Org in PD
- next edit the Org in pd and set the `bdr_person_id` field to the id of the bdr admin in hermes.
- you should see that the Company in hermes is updated with the bdr person id
- you should also see that in TC2 Meta the BDR person is set correctly
- login to meta as `testing@tutorcruncher.com` - doesn't send webhooks
- remove the bdr person
- shell into hermes - look at readme 
- remove the `bdr_person_id` and `bdr_person`
```
company = await Company.get(id=8)
company.bdr_person = None
company.bdr_person_id = None
await company.save()
```
- run patch.py
- see that the bdr_person is added to the company and TC2 Cligency