### PR TITLE
Slugify termation category

### DIFF
--- a/app/tc2/tasks.py
+++ b/app/tc2/tasks.py
@@ -7,6 +7,7 @@ from app.base_schema import HermesBaseModel
 from app.models import Company, CustomField, CustomFieldValue, Deal
 from app.tc2._schema import TCClient
 from app.tc2.api import tc2_request
+from app.utils import sanitise_string
 
 
 async def update_client_from_company(company: Company):
@@ -35,7 +36,7 @@ async def update_client_from_company(company: Company):
 
         for ea in tc_client.extra_attrs:
             if ea.machine_name == 'termination_category':
-                extra_attrs['termination_category'] = ea.value.replace(' ', '-')
+                extra_attrs['termination_category'] = sanitise_string(ea.value)
 
         client_data = tc_client.model_dump()
         client_data['extra_attrs'] = extra_attrs

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import unicodedata
 from typing import TYPE_CHECKING
 
 import aioredis
@@ -44,3 +45,27 @@ async def get_config() -> 'Config':
     # When testing locally, you can add your own admin user here. Set the pd_owner_id to your own Pipedrive user ID.
 
     return config
+
+
+def sanitise_string(input_string: str) -> str:
+    """
+    Sanitises the input string based on the specified rules:
+    - Convert to ASCII
+    - Convert spaces to hyphens
+    - Remove characters that aren't alphanumerics, underscores, or hyphens
+    - Convert to lowercase
+    - Strip leading and trailing whitespace
+    to match django's slugify function
+    """
+
+    # Convert to ASCII
+    ascii_string = unicodedata.normalize('NFKD', input_string).encode('ascii', 'ignore').decode()
+
+    # Convert spaces to hyphens and strip leading/trailing whitespace
+    hyphenated_string = ascii_string.replace(' ', '-').strip()
+
+    # Remove characters that aren't alphanumerics, underscores, or hyphens
+    sanitized_string = ''.join(char for char in hyphenated_string if char.isalnum() or char in ['_', '-'])
+
+    # Convert to lowercase
+    return sanitized_string.lower()

--- a/tests/test_tc2.py
+++ b/tests/test_tc2.py
@@ -777,7 +777,7 @@ class TC2TasksTestCase(HermesTestCase):
     async def test_update_cligency_termination(self, mock_request):
         fake_tc2 = FakeTC2()
         fake_tc2.db['clients'][10]['extra_attrs'] += [
-            {'machine_name': 'termination_category', 'value': 'Too Complicated'}
+            {'machine_name': 'termination_category', 'value': "Doesn't suit business model"},
         ]
         mock_request.side_effect = fake_tc2_request(fake_tc2)
         admin = await Admin.create(pd_owner_id=10, username='testing@example.com', is_sales_person=True)
@@ -788,7 +788,7 @@ class TC2TasksTestCase(HermesTestCase):
         assert fake_tc2.db['clients'][10]['extra_attrs'] == {
             'pipedrive_url': f'{settings.pd_base_url}/organization/20/',
             'who_are_you_trying_to_reach': 'support',
-            'termination_category': 'too-complicated',
+            'termination_category': 'doesnt-suit-business-model',
         }
 
     @mock.patch('app.tc2.api.session.request')


### PR DESCRIPTION
Close #255


## Description

create `sanitise_string` to modify a sting into to the expected output of django's `slugify`

We use this for the terminaion_category





## Testing
- setup with termination_category customfield on tc2
- set the termination for a cligency which has a company in hermes and org on pd
- then update the org, `bdr_person_id` or something to trigger the webhook back to tc2
- see that no api error occured

