### PR TITLE
Handle boolean realtionship between hermes and pd

### DIFF
--- a/app/base_schema.py
+++ b/app/base_schema.py
@@ -150,6 +150,7 @@ class HermesBaseModel(BaseModel):
         hermes_model.
 
         FK fields are handled differently because we need to get the ID of the related object.
+        bool fields are handled differently because they are stored as strings in Pipedrive.
         """
         from app.models import CustomField
 
@@ -171,6 +172,15 @@ class HermesBaseModel(BaseModel):
                     val = getattr(obj, cf.hermes_field_name, None)
                     if val:
                         val = json.dumps(val)
+
+                elif cf.field_type == CustomField.TYPE_BOOL:
+                    val = getattr(obj, cf.hermes_field_name, None)
+                    if isinstance(val, str):
+                        val = val.lower() == 'true'
+                    elif isinstance(val, bool):
+                        val = 'true' if val else 'false'
+                    else:
+                        val = 'false'
 
                 else:
                     val = getattr(obj, cf.hermes_field_name, None)

--- a/app/pipedrive/_schema.py
+++ b/app/pipedrive/_schema.py
@@ -95,7 +95,11 @@ class Organisation(PipedriveBaseModel):
 
     async def company_dict(self, custom_fields: list[CustomField]) -> dict:
         cf_data_from_hermes = {
-            c.hermes_field_name: getattr(self, c.machine_name)
+            c.hermes_field_name: (
+                getattr(self, c.machine_name).lower() == 'true'
+                if c.field_type == CustomField.TYPE_BOOL
+                else getattr(self, c.machine_name)
+            )
             for c in custom_fields
             if c.hermes_field_name and c.field_type != CustomField.TYPE_FK_FIELD
         }

--- a/tests/test_combined.py
+++ b/tests/test_combined.py
@@ -379,6 +379,73 @@ class TestMultipleServices(HermesTestCase):
 
     @mock.patch('app.tc2.api.session.request')
     @mock.patch('app.pipedrive.api.session.request')
+    async def test_tc2_cb_create_company_create_org_update_org_bool(self, mock_pd_request, mock_tc2_get):
+        mock_pd_request.side_effect = fake_pd_request(self.pipedrive)
+        mock_tc2_get.side_effect = fake_tc2_request(self.tc2)
+
+        admin = await Admin.create(
+            tc2_admin_id=30,
+            first_name='Brain',
+            last_name='Johnson',
+            username='brian@tc.com',
+        )
+
+        await CustomField.create(
+            linked_object_type='Company',
+            pd_field_id='123_sales_person_456',
+            hermes_field_name='sales_person',
+            name='Sales Person',
+            field_type=CustomField.TYPE_FK_FIELD,
+        )
+
+        await CustomField.create(
+            linked_object_type='Company',
+            pd_field_id='123_bdr_person_456',
+            hermes_field_name='bdr_person',
+            name='BDR Person',
+            field_type=CustomField.TYPE_FK_FIELD,
+        )
+
+        await CustomField.create(
+            linked_object_type='Company',
+            pd_field_id='123_has_signed_up_456',
+            hermes_field_name='has_signed_up',
+            name='Has Signed Up',
+            field_type=CustomField.TYPE_BOOL,
+        )
+
+        await build_custom_field_schema()
+
+        modified_data = client_full_event_data()
+        modified_data['subject']['meta_agency']['name'] = 'MyTutors'
+        modified_data['subject']['bdr_person'] = None
+        events = [modified_data]
+        data = {'_request_time': 123, 'events': events}
+        r = await self.client.post('/tc2/callback/', json=data, headers={'Webhook-Signature': self._tc2_sig(data)})
+        assert r.status_code == 200, r.json()
+
+        assert await Company.exists()
+        company = await Company.get()
+        assert company.name == 'MyTutors'
+        assert company.has_signed_up
+        assert not company.bdr_person
+        assert await company.support_person == await company.sales_person == admin
+
+        assert self.pipedrive.db['organizations'] == {
+            1: {
+                'id': 1,
+                'name': 'MyTutors',
+                'address_country': 'GB',
+                'owner_id': None,
+                '123_hermes_id_456': company.id,
+                '123_sales_person_456': admin.id,
+                '123_bdr_person_456': None,
+                '123_has_signed_up_456': 'true',
+            }
+        }
+
+    @mock.patch('app.tc2.api.session.request')
+    @mock.patch('app.pipedrive.api.session.request')
     async def test_tc2_cb_create_company_cf_json(self, mock_pd_request, mock_tc2_get):
         mock_pd_request.side_effect = fake_pd_request(self.pipedrive)
         mock_tc2_get.side_effect = fake_tc2_request(self.tc2)


### PR DESCRIPTION
Close #260


## Technical Description

from Company to Organisation

in `get_custom_field_val`; added logic to convert the boolean to a string



from Organisation to Company

in `company_dict` in the `cf_data_from_hermes`

we check if cf type is a bool and convert the string to a bool








-[] need to check test, written but cant get tests working on my mac
