### PR TITLE
Pin tortoise-orm version + Fix incorrectly showing time slots on the callbooker

### DIFF
--- a/app/callbooker/_availability.py
+++ b/app/callbooker/_availability.py
@@ -79,7 +79,7 @@ async def get_admin_available_slots(
     async for day_start, day_end in _get_day_start_ends(start, end, admin.timezone):
         slot_start = day_start
         day_calendar_busy_slots = [s for s in calendar_busy_slots if s['start'] < day_end and s['end'] > day_start]
-        while slot_start + timedelta(minutes=config.meeting_dur_mins + config.meeting_buffer_mins) <= day_end:
+        while slot_start + timedelta(minutes=config.meeting_dur_mins) <= day_end:
             slot_end = slot_start + timedelta(minutes=config.meeting_dur_mins)
             # We check that the slot is not overlapping with any of the busy slots. Either the start or end of the slot
             # is within the busy slot, or the busy slot is within the slot.

--- a/app/callbooker/_availability.py
+++ b/app/callbooker/_availability.py
@@ -86,8 +86,8 @@ async def get_admin_available_slots(
             is_overlapping = False
             for busy_slot in day_calendar_busy_slots:
                 if (
-                    busy_slot['start'] <= slot_start < busy_slot['end']
-                    or busy_slot['start'] < slot_end <= busy_slot['end']
+                    busy_slot['start'] <= slot_start <= busy_slot['end']
+                    or busy_slot['start'] <= slot_end <= busy_slot['end']
                     or (slot_start <= busy_slot['start'] and slot_end >= busy_slot['end'])
                 ):
                     is_overlapping = True

--- a/app/callbooker/_booking.py
+++ b/app/callbooker/_booking.py
@@ -17,7 +17,11 @@ async def check_gcal_open_slots(meeting_start: datetime, meeting_end: datetime, 
     for time_slot in cal_data['calendars'][admin_email]['busy']:
         _slot_start = _iso_8601_to_datetime(time_slot['start'])
         _slot_end = _iso_8601_to_datetime(time_slot['end'])
-        if _slot_start <= meeting_start <= _slot_end or _slot_start <= meeting_end <= _slot_end:
+        if (
+            _slot_start <= meeting_start <= _slot_end
+            or _slot_start <= meeting_end <= _slot_end
+            or (_slot_start <= meeting_start and _slot_end >= meeting_end)
+        ):
             app_logger.info('Tried to book meeting with %s for slot %s - %s', admin_email, _slot_start, _slot_end)
             return False
     return True

--- a/app/settings.py
+++ b/app/settings.py
@@ -13,7 +13,7 @@ class Settings(BaseSettings):
     dev_mode: bool = False
     log_level: str = 'INFO'
 
-    logfire_token: Optional[str] = 'bRRz1JvvNxtg6JBxMGz87d9nN0wgWL4RFVsJJT1wVBCV'
+    logfire_token: Optional[str] = ''
 
     # Postgres
     pg_dsn: PostgresDsn = Field('postgres://postgres@localhost:5432/hermes', validation_alias='DATABASE_URL')

--- a/app/settings.py
+++ b/app/settings.py
@@ -13,7 +13,7 @@ class Settings(BaseSettings):
     dev_mode: bool = False
     log_level: str = 'INFO'
 
-    logfire_token: Optional[str] = ''
+    logfire_token: Optional[str] = None
 
     # Postgres
     pg_dsn: PostgresDsn = Field('postgres://postgres@localhost:5432/hermes', validation_alias='DATABASE_URL')

--- a/app/settings.py
+++ b/app/settings.py
@@ -13,7 +13,7 @@ class Settings(BaseSettings):
     dev_mode: bool = False
     log_level: str = 'INFO'
 
-    logfire_token: Optional[str] = None
+    logfire_token: Optional[str] = 'bRRz1JvvNxtg6JBxMGz87d9nN0wgWL4RFVsJJT1wVBCV'
 
     # Postgres
     pg_dsn: PostgresDsn = Field('postgres://postgres@localhost:5432/hermes', validation_alias='DATABASE_URL')

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ sentry-sdk[fastapi]==2.14.0
 httpx==0.27.2
 opentelemetry-instrumentation-fastapi
 logfire[fastapi]==1.0.0
+tortoise-orm==0.21.6
 tortoise-cli
 
 # Look at all the Google libraries we need to install.

--- a/tests/test_callbooker.py
+++ b/tests/test_callbooker.py
@@ -771,13 +771,12 @@ class AdminAvailabilityTestCase(HermesTestCase):
         slots_9th = [s for s in slots if s[0].startswith('2026-07-09')]
 
         assert len(slots_7th) == 10  # There should be 10 slots in the full day
-        assert len(slots_8th) == 8  # There is a busy section on the 3rd so less slots
+        assert len(slots_8th) == 7  # There is a busy section on the 3rd so less slots
         assert len(slots_9th) == 10  # There should be 10 slots in the full day
 
         assert slots_8th == [
             ['2026-07-08T09:00:00+00:00', '2026-07-08T09:30:00+00:00'],
             ['2026-07-08T09:45:00+00:00', '2026-07-08T10:15:00+00:00'],
-            ['2026-07-08T10:30:00+00:00', '2026-07-08T11:00:00+00:00'],
             ['2026-07-08T12:45:00+00:00', '2026-07-08T13:15:00+00:00'],
             ['2026-07-08T13:30:00+00:00', '2026-07-08T14:00:00+00:00'],
             ['2026-07-08T14:15:00+00:00', '2026-07-08T14:45:00+00:00'],
@@ -893,15 +892,13 @@ class AdminAvailabilityTestCase(HermesTestCase):
         slots_9th = [s for s in slots if s[0].startswith('2026-07-09')]
 
         assert len(slots_7th) == 15  # There should be 10 slots in the full day
-        assert len(slots_8th) == 12  # There is a busy section on the 3rd so less slots
+        assert len(slots_8th) == 10  # There is a busy section on the 3rd so less slots
         assert len(slots_9th) == 15  # There should be 10 slots in the full day
 
         assert slots_8th == [
             ['2026-07-08T09:00:00+00:00', '2026-07-08T09:30:00+00:00'],
             ['2026-07-08T09:30:00+00:00', '2026-07-08T10:00:00+00:00'],
             ['2026-07-08T10:00:00+00:00', '2026-07-08T10:30:00+00:00'],
-            ['2026-07-08T10:30:00+00:00', '2026-07-08T11:00:00+00:00'],
-            ['2026-07-08T12:30:00+00:00', '2026-07-08T13:00:00+00:00'],
             ['2026-07-08T13:00:00+00:00', '2026-07-08T13:30:00+00:00'],
             ['2026-07-08T13:30:00+00:00', '2026-07-08T14:00:00+00:00'],
             ['2026-07-08T14:00:00+00:00', '2026-07-08T14:30:00+00:00'],
@@ -970,6 +967,7 @@ class AdminAvailabilityTestCase(HermesTestCase):
             ['2024-01-09T13:15:00+00:00', '2024-01-09T13:45:00+00:00'],
             ['2024-01-09T14:00:00+00:00', '2024-01-09T14:30:00+00:00'],
             ['2024-01-09T14:45:00+00:00', '2024-01-09T15:15:00+00:00'],
+            ['2024-01-09T17:00:00+00:00', '2024-01-09T17:30:00+00:00'],
         ]
 
 

--- a/tests/test_callbooker.py
+++ b/tests/test_callbooker.py
@@ -28,10 +28,10 @@ def _as_iso_8601(dt: datetime):
     return dt.isoformat().replace('+00:00', 'Z')
 
 
-def fake_gcal_builder(error=False, meeting_dur_mins=90):
+def fake_gcal_builder(error=False, start_dt: datetime = None, meeting_dur_mins: int = 90):
     class MockGCalResource:
         def execute(self):
-            start = datetime(2026, 7, 8, 11, tzinfo=utc)
+            start = start_dt or datetime(2026, 7, 8, 11, tzinfo=utc)
             end = start + timedelta(minutes=meeting_dur_mins)
             return {
                 'calendars': {
@@ -928,6 +928,49 @@ class AdminAvailabilityTestCase(HermesTestCase):
 
         slots_8th = [s for s in slots if s[0].startswith('2026-07-08')]
         assert ['2026-07-08T11:00:00+00:00', '2026-07-08T11:30:00+00:00'] not in slots_8th
+
+    async def test_availability_admin_busy_end(self, mock_gcal_builder):
+        """
+        Tests the scenario where a meeting is booked not on the callbooker so the admin is busy at a random interval.
+        In this test, they have a meeting from 4pm -> 4:30pm which clashes with 2 meetings.
+
+        All slots free until the 4pm meeting where the 3:30pm -> 4pm is blocked by the meeting that starts at 4pm
+        and then the next slot at 4:15pm -> 4:45pm is also blocked by the 30min meeting that starts at 4pm and finally
+        the 5pm slot is blocked because although the 5pm -> 5:30pm is free, we check the meeting length + buffer is
+        less than the day end of 5:31pm which it isn't (that would be 5pm + 30min meeting + 15 min buffer).
+        """
+        self.config.meeting_dur_mins = 30
+        self.config.meeting_buffer_mins = 15
+        self.config.meeting_min_start = '08:00'
+        self.config.meeting_max_end = '17:31'
+        await self.config.save()
+
+        admin = await Admin.create(
+            first_name='Steve', last_name='Jobs', username='climan@example.com', is_sales_person=True
+        )
+
+        start_dt = datetime(2024, 1, 9, 16, tzinfo=utc)
+        mock_gcal_builder.side_effect = fake_gcal_builder(start_dt=start_dt, meeting_dur_mins=30)
+
+        start = datetime(2024, 1, 9, 2, tzinfo=utc)
+        end = datetime(2024, 1, 9, 23, tzinfo=utc)
+        r = await self.client.get(
+            self.url, params={'admin_id': admin.id, 'start_dt': start.timestamp(), 'end_dt': end.timestamp()}
+        )
+        slots = r.json()['slots']
+
+        assert slots == [
+            ['2024-01-09T08:00:00+00:00', '2024-01-09T08:30:00+00:00'],
+            ['2024-01-09T08:45:00+00:00', '2024-01-09T09:15:00+00:00'],
+            ['2024-01-09T09:30:00+00:00', '2024-01-09T10:00:00+00:00'],
+            ['2024-01-09T10:15:00+00:00', '2024-01-09T10:45:00+00:00'],
+            ['2024-01-09T11:00:00+00:00', '2024-01-09T11:30:00+00:00'],
+            ['2024-01-09T11:45:00+00:00', '2024-01-09T12:15:00+00:00'],
+            ['2024-01-09T12:30:00+00:00', '2024-01-09T13:00:00+00:00'],
+            ['2024-01-09T13:15:00+00:00', '2024-01-09T13:45:00+00:00'],
+            ['2024-01-09T14:00:00+00:00', '2024-01-09T14:30:00+00:00'],
+            ['2024-01-09T14:45:00+00:00', '2024-01-09T15:15:00+00:00'],
+        ]
 
 
 class SupportLinkTestCase(HermesTestCase):


### PR DESCRIPTION
### Technical description of changes:
* Pinned tortoise-orm to a version so it doesn't break anything.
* Made a change to available slots so that the 5pm -> 5:30pm slot can now be booked if it doesn't clash
* The availability endpoint now follows the logic from the booking a call so that we don't get errors. Eg. If a sales person has a meeting at 4pm we no longer display the time 3:30 -> 4pm as it causes errors on our side.
* Updated `check_gcal_open_slots` to include a check that was in `get_admin_available_slots` that I felt was missing

### Recreation steps:
* In website new add a callbooker for yourself in `data.ts` or just use mine and put stuff in my calendar to test:
```python
  {
    rep_name: "Dan",
    callbooker_url: "/book-a-call/dan/",
    img_path: "/img/reps/dan_blue.png",
    hermes_admin_id: 11,
    alt_rep_name: "Raashi",
    alt_callbooker_url: "/book-a-call/raashi/",
    alt_rep_hermes_admin_id: 4,
    description: "",
  },
```
* Run the new website with `npm run dev`
* Run hermes with `python -m uvicorn app.main:app --reload --port 8001`
* In new website repo, change `NEXT_PUBLIC_HERMES_BASE_URL: process.env.NEXT_PUBLIC_HERMES_BASE_URL || "https://hermes.tutorcruncher.com",
` -> `NEXT_PUBLIC_HERMES_BASE_URL: process.env.NEXT_PUBLIC_HERMES_BASE_URL || "http://localhost:8001",`
* On hermes run `make restore-from-live`
* Get your hermes admin id after logging into hermes and set that in your callbooker on new website if you're not using my callbooker
* Set up a meeting at 4pm -> 4:30pm and then try book a call in the 3:30pm -> 4pm slot
* See the error

### Manual testing:
* Check that the slot now doesn't appear if it can't be booked
* Check sams call booker times and check against his calendar/the callbooker on tc.com rn and check it all makes sense
* Anything else you can think of