### PR TITLE
Patch owner ids for Companies and Deals

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -350,7 +350,7 @@ async def sync_deal_owners_from_pipedrive(db):
     print(f'Loaded {len(admins)} admins')
     print(f'pd_owner_id to admin.id mapping: {len(pd_owner_to_admin)} entries')
 
-    deals = db.exec(select(Deal).where(Deal.admin_id.not_in([SAM_ID, FIONN_ID, TONY_ID, DREW_ID]))).all()
+    deals = db.exec(select(Deal).where(Deal.admin_id.not_in([SAM_ID, FIONN_ID, GABE_ID, TONY_ID, DREW_ID]))).all()
     hermes_deal_map = {deal.pd_deal_id: deal for deal in deals if deal.pd_deal_id}
 
     print(f'Found {len(deals)} deals')


### PR DESCRIPTION
Patch Descriptions

1. reassign_companies_by_price_plan
Reassigns companies with sales_person_id 3 or 4 (Maahi and Raashi) to correct admins based on
price plan (payg/startup -> Sam, enterprise -> Fionn). Also updates all related deals.

2. sync_deals_without_pd_id
Links Hermes deals with missing pd_deal_id to existing Pipedrive deals by matching company org_id and deal name. Uses fuzzy substring matching when org_id exists, else exact matching otherwise.

3. sync_deal_owners_from_pipedrive
Corrects admin_id for deals with incorrect owner assignments (3, 4, or 8) by fetching current owner_id from Pipedrive and mapping to correct Hermes admin.
<img width="1132" height="264" alt="image" src="https://github.com/user-attachments/assets/3b78dd7e-9f2c-453b-94cb-5e4bceed9bb0" />

So most the erroneous admin id 8 gets updated to 9 (Tony)

Order to run
 1 -> 2 -> 3, though 1 can be run in any order
