### PR TITLE
Patch to fix Companies with old pd_owner_ids

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -21,17 +21,6 @@ logger = logging.getLogger('hermes.patch')
 
 commands = []
 
-'''
-1	"Sam"
-2	"Fionn"
-3	"Maahi"
-4	"Raashi"
-6	"Tom"
-9	"Tony"
-7	"Gabe"
-15	"Drew"
-'''
-
 SAM_ID = 1
 FIONN_ID = 2
 MAAHI_ID = 3
@@ -40,8 +29,8 @@ TOM_ID = 6
 GABE_ID = 7
 DAN_ID = 8
 TONY_ID = 9
-DREW_ID = 15
 CHRIS_ID = 11
+DREW_ID = 15
 
 INACTIVE_ADMIN_IDS = [TOM_ID, DAN_ID, 11, 13]  # Tom, Daniel, Chris, Drew (old id=13)
 INACTIVE_BDR_IDS = [TOM_ID, DAN_ID, 13]  # Tom, Daniel, Drew (old id=13)


### PR DESCRIPTION
Close #366, #368

Patches to run:
1.  `reassign_inactive_sales_person_companies` - companies with inactive sales person ids are assigned to the correct ones and then if the companies have any deal which are assigned to someone outside of the sales team, we assign it back to the sales person of the company
2. `reassign_inactive_bdr_person_companies` - companies with inactive bdr persons are assigned to the correct bdr person.
3. `reassign_deals_with_invalid_admin` - deals that have admin id as `None` or 0 (invalid) are assigned to their respective Comapnies sales person.