### PR TITLE
Fix for race condition in new signups flow

### DIFF
--- a/app/core/locks.py
+++ b/app/core/locks.py
@@ -1,0 +1,54 @@
+import asyncio
+
+
+class _RefCountedLock:
+    """
+    Lock wrapper to track how many coroutines are waiting on or holding the lock.
+    """
+
+    def __init__(self):
+        self._lock = asyncio.Lock()
+        self._count = 0
+
+    async def __aenter__(self):
+        """
+        async enter called when entering the `async with` block
+        """
+        self._count += 1
+        try:
+            await self._lock.acquire()
+        except BaseException:
+            self._count -= 1
+            raise
+        return self
+
+    async def __aexit__(self, *exc):
+        """
+        called on exiting the async block
+        """
+        self._lock.release()
+        self._count -= 1
+
+    @property
+    def in_use(self):
+        return self._count > 0
+
+
+class LockRegistry:
+    """
+    Per ID lock for a safe cleanup. Each ID gets its own lock so concurrent operations on different IDs
+    run in parallel while the operations on the same ID are serialised.
+    """
+
+    def __init__(self):
+        self._locks: dict[int, _RefCountedLock] = {}
+
+    def get(self, key: int) -> _RefCountedLock:
+        if key not in self._locks:
+            self._locks[key] = _RefCountedLock()
+        return self._locks[key]
+
+    def release(self, key: int) -> None:
+        lock = self._locks.get(key)
+        if lock and not lock.in_use:
+            self._locks.pop(key, None)

--- a/app/core/locks.py
+++ b/app/core/locks.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import asynccontextmanager
 
 
 class _RefCountedLock:
@@ -43,12 +44,21 @@ class LockRegistry:
     def __init__(self):
         self._locks: dict[int, _RefCountedLock] = {}
 
-    def get(self, key: int) -> _RefCountedLock:
+    def _get(self, key: int) -> _RefCountedLock:
         if key not in self._locks:
             self._locks[key] = _RefCountedLock()
         return self._locks[key]
 
-    def release(self, key: int) -> None:
+    def _release(self, key: int) -> None:
         lock = self._locks.get(key)
         if lock and not lock.in_use:
             self._locks.pop(key, None)
+
+    @asynccontextmanager
+    async def acquire(self, key: int):
+        lock = self._get(key)
+        try:
+            async with lock:
+                yield
+        finally:
+            self._release(key)

--- a/app/pipedrive/tasks.py
+++ b/app/pipedrive/tasks.py
@@ -16,7 +16,6 @@ SYNCABLE_DEAL_FIELDS = ['paid_invoice_count']  # these fields get synced from de
 
 # Per-company asyncio locks to serialise concurrent syncs for the same company.
 # Only valid because Hermes runs a single uvicorn worker (see Procfile).
-# Lock objects are tiny; unbounded growth is fine for the volume of companies we see.
 _company_sync_locks: dict[int, asyncio.Lock] = {}
 
 

--- a/app/pipedrive/tasks.py
+++ b/app/pipedrive/tasks.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from datetime import datetime
 
@@ -13,48 +14,57 @@ logger = logging.getLogger('hermes.pipedrive')
 
 SYNCABLE_DEAL_FIELDS = ['paid_invoice_count']  # these fields get synced from deal company
 
+_company_sync_locks: dict[int, asyncio.Lock] = {}
+
+
+def _get_company_lock(company_id: int) -> asyncio.Lock:
+    if company_id not in _company_sync_locks:
+        _company_sync_locks[company_id] = asyncio.Lock()
+    return _company_sync_locks[company_id]
+
 
 async def sync_company_to_pipedrive(company_id: int):
     """
     Sync company and related data to Pipedrive.
     This is called after TC2 or Callbooker updates.
     """
-    with logfire.span('sync_company_to_pipedrive'):
-        try:
-            with get_session() as db:
-                company = db.get(Company, company_id)
-                if not company:
-                    logger.warning(f'Company {company_id} not found, skipping sync')
-                    return
-                if company.is_deleted:
-                    logger.info(f'Company {company_id} is marked as deleted, skipping sync')
-                    return
+    async with _get_company_lock(company_id):
+        with logfire.span('sync_company_to_pipedrive'):
+            try:
+                with get_session() as db:
+                    company = db.get(Company, company_id)
+                    if not company:
+                        logger.warning(f'Company {company_id} not found, skipping sync')
+                        return
+                    if company.is_deleted:
+                        logger.info(f'Company {company_id} is marked as deleted, skipping sync')
+                        return
 
-                contact_ids = [c.id for c in db.exec(select(Contact).where(Contact.company_id == company_id)).all()]
+                    contact_ids = [c.id for c in db.exec(select(Contact).where(Contact.company_id == company_id)).all()]
 
-                deal_query = select(Deal).where(Deal.company_id == company_id)
-                if not company.paid_invoice_count:
-                    # Full sync for non-paying companies (update existing + create new open deals)
-                    deal_query = deal_query.where((Deal.pd_deal_id.is_not(None)) | (Deal.status == Deal.STATUS_OPEN))
-                    only_syncable_deal_fields = False
-                else:
-                    # Only sync fields for paying companies' existing open deals
-                    deal_query = deal_query.where(Deal.pd_deal_id.is_not(None), Deal.status == Deal.STATUS_OPEN)
-                    only_syncable_deal_fields = True
+                    deal_query = select(Deal).where(Deal.company_id == company_id)
+                    if not company.paid_invoice_count:
+                        # Full sync for non-paying companies (update existing + create new open deals)
+                        deal_query = deal_query.where((Deal.pd_deal_id.is_not(None)) | (Deal.status == Deal.STATUS_OPEN))
+                        only_syncable_deal_fields = False
+                    else:
+                        # Only sync fields for paying companies' existing open deals
+                        deal_query = deal_query.where(Deal.pd_deal_id.is_not(None), Deal.status == Deal.STATUS_OPEN)
+                        only_syncable_deal_fields = True
 
-                deal_ids = [d.id for d in db.exec(deal_query).all()]
+                    deal_ids = [d.id for d in db.exec(deal_query).all()]
 
-            await sync_organization(company_id)
+                await sync_organization(company_id)
 
-            for contact_id in contact_ids:
-                await sync_person(contact_id)
+                for contact_id in contact_ids:
+                    await sync_person(contact_id)
 
-            for deal_id in deal_ids:
-                await sync_deal(deal_id, only_syncable_deal_fields)
+                for deal_id in deal_ids:
+                    await sync_deal(deal_id, only_syncable_deal_fields)
 
-            logger.info(f'Successfully synced company {company_id} to Pipedrive')
-        except Exception as e:
-            logger.error(f'Error syncing company {company_id}: {e}', exc_info=True)
+                logger.info(f'Successfully synced company {company_id} to Pipedrive')
+            except Exception as e:
+                logger.error(f'Error syncing company {company_id}: {e}', exc_info=True)
 
 
 async def sync_organization(company_id: int):

--- a/app/pipedrive/tasks.py
+++ b/app/pipedrive/tasks.py
@@ -21,6 +21,10 @@ _company_sync_locks: dict[int, asyncio.Lock] = {}
 
 
 def _get_company_lock(company_id: int) -> asyncio.Lock:
+    """
+    same as `_get_cligency_lock` but this will be utilised in the sync `BackgroundTasks`
+    and will have a lock per company id supplied to background task
+    """
     if company_id not in _company_sync_locks:
         _company_sync_locks[company_id] = asyncio.Lock()
     return _company_sync_locks[company_id]

--- a/app/pipedrive/tasks.py
+++ b/app/pipedrive/tasks.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from datetime import datetime
 
@@ -6,6 +5,7 @@ import logfire
 from sqlmodel import select
 
 from app.core.database import get_session
+from app.core.locks import LockRegistry
 from app.main_app.models import Company, Contact, Deal, Meeting
 from app.pipedrive import api
 from app.pipedrive.field_mappings import COMPANY_PD_FIELD_MAP, CONTACT_PD_FIELD_MAP, DEAL_PD_FIELD_MAP
@@ -14,19 +14,9 @@ logger = logging.getLogger('hermes.pipedrive')
 
 SYNCABLE_DEAL_FIELDS = ['paid_invoice_count']  # these fields get synced from deal company
 
-# Per-company asyncio locks to serialise concurrent syncs for the same company.
+# Per-company locks to serialise concurrent syncs for the same company.
 # Only valid because Hermes runs a single uvicorn worker (see Procfile).
-_company_sync_locks: dict[int, asyncio.Lock] = {}
-
-
-def _get_company_lock(company_id: int) -> asyncio.Lock:
-    """
-    same as `_get_cligency_lock` but this will be utilised in the sync `BackgroundTasks`
-    and will have a lock per company id supplied to background task
-    """
-    if company_id not in _company_sync_locks:
-        _company_sync_locks[company_id] = asyncio.Lock()
-    return _company_sync_locks[company_id]
+_company_sync_locks = LockRegistry()
 
 
 async def sync_company_to_pipedrive(company_id: int):
@@ -34,45 +24,51 @@ async def sync_company_to_pipedrive(company_id: int):
     Sync company and related data to Pipedrive.
     This is called after TC2 or Callbooker updates.
     """
-    async with _get_company_lock(company_id):
-        with logfire.span('sync_company_to_pipedrive'):
-            try:
-                with get_session() as db:
-                    company = db.get(Company, company_id)
-                    if not company:
-                        logger.warning(f'Company {company_id} not found, skipping sync')
-                        return
-                    if company.is_deleted:
-                        logger.info(f'Company {company_id} is marked as deleted, skipping sync')
-                        return
+    lock = _company_sync_locks.get(company_id)
+    try:
+        async with lock:
+            with logfire.span('sync_company_to_pipedrive'):
+                try:
+                    with get_session() as db:
+                        company = db.get(Company, company_id)
+                        if not company:
+                            logger.warning(f'Company {company_id} not found, skipping sync')
+                            return
+                        if company.is_deleted:
+                            logger.info(f'Company {company_id} is marked as deleted, skipping sync')
+                            return
 
-                    contact_ids = [c.id for c in db.exec(select(Contact).where(Contact.company_id == company_id)).all()]
+                        contact_ids = [
+                            c.id for c in db.exec(select(Contact).where(Contact.company_id == company_id)).all()
+                        ]
 
-                    deal_query = select(Deal).where(Deal.company_id == company_id)
-                    if not company.paid_invoice_count:
-                        # Full sync for non-paying companies (update existing + create new open deals)
-                        deal_query = deal_query.where(
-                            (Deal.pd_deal_id.is_not(None)) | (Deal.status == Deal.STATUS_OPEN)
-                        )
-                        only_syncable_deal_fields = False
-                    else:
-                        # Only sync fields for paying companies' existing open deals
-                        deal_query = deal_query.where(Deal.pd_deal_id.is_not(None), Deal.status == Deal.STATUS_OPEN)
-                        only_syncable_deal_fields = True
+                        deal_query = select(Deal).where(Deal.company_id == company_id)
+                        if not company.paid_invoice_count:
+                            # Full sync for non-paying companies (update existing + create new open deals)
+                            deal_query = deal_query.where(
+                                (Deal.pd_deal_id.is_not(None)) | (Deal.status == Deal.STATUS_OPEN)
+                            )
+                            only_syncable_deal_fields = False
+                        else:
+                            # Only sync fields for paying companies' existing open deals
+                            deal_query = deal_query.where(Deal.pd_deal_id.is_not(None), Deal.status == Deal.STATUS_OPEN)
+                            only_syncable_deal_fields = True
 
-                    deal_ids = [d.id for d in db.exec(deal_query).all()]
+                        deal_ids = [d.id for d in db.exec(deal_query).all()]
 
-                await sync_organization(company_id)
+                    await sync_organization(company_id)
 
-                for contact_id in contact_ids:
-                    await sync_person(contact_id)
+                    for contact_id in contact_ids:
+                        await sync_person(contact_id)
 
-                for deal_id in deal_ids:
-                    await sync_deal(deal_id, only_syncable_deal_fields)
+                    for deal_id in deal_ids:
+                        await sync_deal(deal_id, only_syncable_deal_fields)
 
-                logger.info(f'Successfully synced company {company_id} to Pipedrive')
-            except Exception as e:
-                logger.error(f'Error syncing company {company_id}: {e}', exc_info=True)
+                    logger.info(f'Successfully synced company {company_id} to Pipedrive')
+                except Exception as e:
+                    logger.error(f'Error syncing company {company_id}: {e}', exc_info=True)
+    finally:
+        _company_sync_locks.release(company_id)
 
 
 async def sync_organization(company_id: int):

--- a/app/pipedrive/tasks.py
+++ b/app/pipedrive/tasks.py
@@ -14,6 +14,9 @@ logger = logging.getLogger('hermes.pipedrive')
 
 SYNCABLE_DEAL_FIELDS = ['paid_invoice_count']  # these fields get synced from deal company
 
+# Per-company asyncio locks to serialise concurrent syncs for the same company.
+# Only valid because Hermes runs a single uvicorn worker (see Procfile).
+# Lock objects are tiny; unbounded growth is fine for the volume of companies we see.
 _company_sync_locks: dict[int, asyncio.Lock] = {}
 
 
@@ -45,7 +48,9 @@ async def sync_company_to_pipedrive(company_id: int):
                     deal_query = select(Deal).where(Deal.company_id == company_id)
                     if not company.paid_invoice_count:
                         # Full sync for non-paying companies (update existing + create new open deals)
-                        deal_query = deal_query.where((Deal.pd_deal_id.is_not(None)) | (Deal.status == Deal.STATUS_OPEN))
+                        deal_query = deal_query.where(
+                            (Deal.pd_deal_id.is_not(None)) | (Deal.status == Deal.STATUS_OPEN)
+                        )
                         only_syncable_deal_fields = False
                     else:
                         # Only sync fields for paying companies' existing open deals

--- a/app/pipedrive/tasks.py
+++ b/app/pipedrive/tasks.py
@@ -24,51 +24,45 @@ async def sync_company_to_pipedrive(company_id: int):
     Sync company and related data to Pipedrive.
     This is called after TC2 or Callbooker updates.
     """
-    lock = _company_sync_locks.get(company_id)
-    try:
-        async with lock:
-            with logfire.span('sync_company_to_pipedrive'):
-                try:
-                    with get_session() as db:
-                        company = db.get(Company, company_id)
-                        if not company:
-                            logger.warning(f'Company {company_id} not found, skipping sync')
-                            return
-                        if company.is_deleted:
-                            logger.info(f'Company {company_id} is marked as deleted, skipping sync')
-                            return
+    async with _company_sync_locks.acquire(company_id):
+        with logfire.span('sync_company_to_pipedrive'):
+            try:
+                with get_session() as db:
+                    company = db.get(Company, company_id)
+                    if not company:
+                        logger.warning(f'Company {company_id} not found, skipping sync')
+                        return
+                    if company.is_deleted:
+                        logger.info(f'Company {company_id} is marked as deleted, skipping sync')
+                        return
 
-                        contact_ids = [
-                            c.id for c in db.exec(select(Contact).where(Contact.company_id == company_id)).all()
-                        ]
+                    contact_ids = [c.id for c in db.exec(select(Contact).where(Contact.company_id == company_id)).all()]
 
-                        deal_query = select(Deal).where(Deal.company_id == company_id)
-                        if not company.paid_invoice_count:
-                            # Full sync for non-paying companies (update existing + create new open deals)
-                            deal_query = deal_query.where(
-                                (Deal.pd_deal_id.is_not(None)) | (Deal.status == Deal.STATUS_OPEN)
-                            )
-                            only_syncable_deal_fields = False
-                        else:
-                            # Only sync fields for paying companies' existing open deals
-                            deal_query = deal_query.where(Deal.pd_deal_id.is_not(None), Deal.status == Deal.STATUS_OPEN)
-                            only_syncable_deal_fields = True
+                    deal_query = select(Deal).where(Deal.company_id == company_id)
+                    if not company.paid_invoice_count:
+                        # Full sync for non-paying companies (update existing + create new open deals)
+                        deal_query = deal_query.where(
+                            (Deal.pd_deal_id.is_not(None)) | (Deal.status == Deal.STATUS_OPEN)
+                        )
+                        only_syncable_deal_fields = False
+                    else:
+                        # Only sync fields for paying companies' existing open deals
+                        deal_query = deal_query.where(Deal.pd_deal_id.is_not(None), Deal.status == Deal.STATUS_OPEN)
+                        only_syncable_deal_fields = True
 
-                        deal_ids = [d.id for d in db.exec(deal_query).all()]
+                    deal_ids = [d.id for d in db.exec(deal_query).all()]
 
-                    await sync_organization(company_id)
+                await sync_organization(company_id)
 
-                    for contact_id in contact_ids:
-                        await sync_person(contact_id)
+                for contact_id in contact_ids:
+                    await sync_person(contact_id)
 
-                    for deal_id in deal_ids:
-                        await sync_deal(deal_id, only_syncable_deal_fields)
+                for deal_id in deal_ids:
+                    await sync_deal(deal_id, only_syncable_deal_fields)
 
-                    logger.info(f'Successfully synced company {company_id} to Pipedrive')
-                except Exception as e:
-                    logger.error(f'Error syncing company {company_id}: {e}', exc_info=True)
-    finally:
-        _company_sync_locks.release(company_id)
+                logger.info(f'Successfully synced company {company_id} to Pipedrive')
+            except Exception as e:
+                logger.error(f'Error syncing company {company_id}: {e}', exc_info=True)
 
 
 async def sync_organization(company_id: int):

--- a/app/tc2/views.py
+++ b/app/tc2/views.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Optional
 
@@ -12,6 +13,17 @@ from app.tc2.process import process_tc_client
 logger = logging.getLogger('hermes.tc2')
 
 router = APIRouter(prefix='/tc2', tags=['tc2'])
+
+# Per-cligency lock to serialise concurrent webhook processing for the same TC2 client.
+# Prevents duplicate Hermes Deal rows when CREATED_A_CLIENT and EDITED_A_CLIENT
+# arrive as near-simultaneous separate requests from TC2 batched webhooks.
+_cligency_locks: dict[int, asyncio.Lock] = {}
+
+
+def _get_cligency_lock(cligency_id: int) -> asyncio.Lock:
+    if cligency_id not in _cligency_locks:
+        _cligency_locks[cligency_id] = asyncio.Lock()
+    return _cligency_locks[cligency_id]
 
 
 @router.post('/callback/', name='tc2-callback')
@@ -38,17 +50,18 @@ async def tc2_callback(
                 continue
 
             try:
-                # Process the client (creates/updates Company and Contacts)
-                with get_session() as db:
-                    company = await process_tc_client(TCClient(**event.subject.model_dump()), db)
+                async with _get_cligency_lock(event.subject.id):
+                    # Process the client (creates/updates Company and Contacts)
+                    with get_session() as db:
+                        company = await process_tc_client(TCClient(**event.subject.model_dump()), db)
 
-                if company:
-                    # Queue background task to sync to Pipedrive
-                    if company.narc:
-                        # NARC companies are deleted/purged from Pipedrive
-                        background_tasks.add_task(purge_company_from_pipedrive, company.id)
-                    else:
-                        background_tasks.add_task(sync_company_to_pipedrive, company.id)
+                    if company:
+                        # Queue background task to sync to Pipedrive
+                        if company.narc:
+                            # NARC companies are deleted/purged from Pipedrive
+                            background_tasks.add_task(purge_company_from_pipedrive, company.id)
+                        else:
+                            background_tasks.add_task(sync_company_to_pipedrive, company.id)
 
             except Exception as e:
                 logger.error(f'Error processing TC2 client event: {e}', exc_info=True)

--- a/app/tc2/views.py
+++ b/app/tc2/views.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from typing import Optional
 
@@ -6,6 +5,7 @@ from fastapi import APIRouter, BackgroundTasks, Header
 
 from app.core.config import settings
 from app.core.database import get_session
+from app.core.locks import LockRegistry
 from app.pipedrive.tasks import purge_company_from_pipedrive, sync_company_to_pipedrive
 from app.tc2.models import TCClient, TCWebhook
 from app.tc2.process import process_tc_client
@@ -17,17 +17,7 @@ router = APIRouter(prefix='/tc2', tags=['tc2'])
 # Per-cligency lock to serialise concurrent webhook processing for the same TC2 client.
 # Prevents duplicate Hermes Deal rows when CREATED_A_CLIENT and EDITED_A_CLIENT
 # arrive as near-simultaneous separate requests from TC2 batched webhooks.
-_cligency_locks: dict[int, asyncio.Lock] = {}
-
-
-def _get_cligency_lock(cligency_id: int) -> asyncio.Lock:
-    """
-    builds a dict of per cligency lock, so that concurrent action webhooks for the same cligency
-    utilise the locking mechanism. This avoids holding a global lock for unique cligency actions
-    """
-    if cligency_id not in _cligency_locks:
-        _cligency_locks[cligency_id] = asyncio.Lock()
-    return _cligency_locks[cligency_id]
+_cligency_locks = LockRegistry()
 
 
 @router.post('/callback/', name='tc2-callback')
@@ -53,10 +43,9 @@ async def tc2_callback(
                 logger.info('Ignoring AGREE_TERMS event')
                 continue
 
+            lock = _cligency_locks.get(event.subject.id)
             try:
-                async with _get_cligency_lock(event.subject.id):
-                    # the cligency lock will prevent concurrrent WH requests from creating duplicate
-                    # companies in `process_tc_client` (case where WH1 and WH2 both creates a new company in the signup flow)
+                async with lock:
                     # Process the client (creates/updates Company and Contacts)
                     with get_session() as db:
                         company = await process_tc_client(TCClient(**event.subject.model_dump()), db)
@@ -64,13 +53,14 @@ async def tc2_callback(
                     if company:
                         # Queue background task to sync to Pipedrive
                         if company.narc:
-                            # NARC companies are deleted/purged from Pipedrive
                             background_tasks.add_task(purge_company_from_pipedrive, company.id)
                         else:
                             background_tasks.add_task(sync_company_to_pipedrive, company.id)
 
             except Exception as e:
                 logger.error(f'Error processing TC2 client event: {e}', exc_info=True)
+            finally:
+                _cligency_locks.release(event.subject.id)
 
         else:
             logger.info(f'Ignoring event with subject model {event.subject.model}')

--- a/app/tc2/views.py
+++ b/app/tc2/views.py
@@ -43,9 +43,8 @@ async def tc2_callback(
                 logger.info('Ignoring AGREE_TERMS event')
                 continue
 
-            lock = _cligency_locks.get(event.subject.id)
             try:
-                async with lock:
+                async with _cligency_locks.acquire(event.subject.id):
                     # Process the client (creates/updates Company and Contacts)
                     with get_session() as db:
                         company = await process_tc_client(TCClient(**event.subject.model_dump()), db)
@@ -59,8 +58,6 @@ async def tc2_callback(
 
             except Exception as e:
                 logger.error(f'Error processing TC2 client event: {e}', exc_info=True)
-            finally:
-                _cligency_locks.release(event.subject.id)
 
         else:
             logger.info(f'Ignoring event with subject model {event.subject.model}')

--- a/app/tc2/views.py
+++ b/app/tc2/views.py
@@ -21,6 +21,10 @@ _cligency_locks: dict[int, asyncio.Lock] = {}
 
 
 def _get_cligency_lock(cligency_id: int) -> asyncio.Lock:
+    """
+    builds a dict of per cligency lock, so that concurrent action webhooks for the same cligency
+    utilise the locking mechanism. This avoids holding a global lock for unique cligency actions
+    """
     if cligency_id not in _cligency_locks:
         _cligency_locks[cligency_id] = asyncio.Lock()
     return _cligency_locks[cligency_id]
@@ -51,6 +55,8 @@ async def tc2_callback(
 
             try:
                 async with _get_cligency_lock(event.subject.id):
+                    # the cligency lock will prevent concurrrent WH requests from creating duplicate
+                    # companies in `process_tc_client` (case where WH1 and WH2 both creates a new company in the signup flow)
                     # Process the client (creates/updates Company and Contacts)
                     with get_session() as db:
                         company = await process_tc_client(TCClient(**event.subject.model_dump()), db)

--- a/tests/core/test_locks.py
+++ b/tests/core/test_locks.py
@@ -13,38 +13,27 @@ class TestLockRegistry:
     async def test_cleanup_after_normal_completion(self):
         """Lock is removed from the registry after the work finishes normally."""
         registry = LockRegistry()
-        lock = registry.get(1)
-        async with lock:
+        async with registry.acquire(1):
             assert 1 in registry._locks
-        registry.release(1)
         assert 1 not in registry._locks
 
     async def test_cleanup_after_body_raises(self):
         """Lock is removed from the registry even when the body raises an exception."""
         registry = LockRegistry()
-        lock = registry.get(1)
         with pytest.raises(ValueError):
-            try:
-                async with lock:
-                    raise ValueError('boom')
-            finally:
-                registry.release(1)
+            async with registry.acquire(1):
+                raise ValueError('boom')
         assert 1 not in registry._locks
 
     async def test_cleanup_after_waiter_cancelled(self):
         """Lock is removed after a queued waiter is cancelled mid-wait."""
         registry = LockRegistry()
 
-        lock = registry.get(1)
-        async with lock:
-            # Start a second task that will wait on the same lock
+        async with registry.acquire(1):
+
             async def waiter():
-                wlock = registry.get(1)
-                try:
-                    async with wlock:
-                        pass
-                finally:
-                    registry.release(1)
+                async with registry.acquire(1):
+                    pass
 
             task = asyncio.create_task(waiter())
             # Let the waiter reach the acquire() and block
@@ -53,8 +42,6 @@ class TestLockRegistry:
             task.cancel()
             await asyncio.sleep(0)
 
-        # First holder exits, release its side
-        registry.release(1)
         assert 1 not in registry._locks
 
     async def test_lock_not_evicted_while_waiter_queued(self):
@@ -62,21 +49,15 @@ class TestLockRegistry:
         registry = LockRegistry()
         entered = asyncio.Event()
 
-        lock = registry.get(1)
-        async with lock:
+        async with registry.acquire(1):
 
             async def waiter():
-                wlock = registry.get(1)
-                try:
-                    async with wlock:
-                        entered.set()
-                finally:
-                    registry.release(1)
+                async with registry.acquire(1):
+                    entered.set()
 
             task = asyncio.create_task(waiter())
             await asyncio.sleep(0)
-            # Holder releases — should NOT evict because waiter is queued
-            registry.release(1)
+            # Waiter is queued, lock should still be in the registry
             assert 1 in registry._locks
 
         # Let waiter finish
@@ -90,14 +71,10 @@ class TestLockRegistry:
         order = []
 
         async def work(key, label):
-            lock = registry.get(key)
-            try:
-                async with lock:
-                    order.append(f'{label}_start')
-                    await asyncio.sleep(0)
-                    order.append(f'{label}_end')
-            finally:
-                registry.release(key)
+            async with registry.acquire(key):
+                order.append(f'{label}_start')
+                await asyncio.sleep(0)
+                order.append(f'{label}_end')
 
         await asyncio.gather(work(1, 'a'), work(2, 'b'))
         # Both should interleave since they use different keys

--- a/tests/core/test_locks.py
+++ b/tests/core/test_locks.py
@@ -1,0 +1,106 @@
+import asyncio
+
+import pytest
+
+from app.core.locks import LockRegistry
+
+
+class TestLockRegistry:
+    """Tests that the LockRegistry correctly removes locks from its internal dict
+    when they are no longer needed, and keeps them when they are still in use.
+    Covers normal completion, exceptions, cancellation, and concurrent use."""
+
+    async def test_cleanup_after_normal_completion(self):
+        """Lock is removed from the registry after the work finishes normally."""
+        registry = LockRegistry()
+        lock = registry.get(1)
+        async with lock:
+            assert 1 in registry._locks
+        registry.release(1)
+        assert 1 not in registry._locks
+
+    async def test_cleanup_after_body_raises(self):
+        """Lock is removed from the registry even when the body raises an exception."""
+        registry = LockRegistry()
+        lock = registry.get(1)
+        with pytest.raises(ValueError):
+            try:
+                async with lock:
+                    raise ValueError('boom')
+            finally:
+                registry.release(1)
+        assert 1 not in registry._locks
+
+    async def test_cleanup_after_waiter_cancelled(self):
+        """Lock is removed after a queued waiter is cancelled mid-wait."""
+        registry = LockRegistry()
+
+        lock = registry.get(1)
+        async with lock:
+            # Start a second task that will wait on the same lock
+            async def waiter():
+                wlock = registry.get(1)
+                try:
+                    async with wlock:
+                        pass
+                finally:
+                    registry.release(1)
+
+            task = asyncio.create_task(waiter())
+            # Let the waiter reach the acquire() and block
+            await asyncio.sleep(0)
+            # Cancel it while it's waiting
+            task.cancel()
+            await asyncio.sleep(0)
+
+        # First holder exits, release its side
+        registry.release(1)
+        assert 1 not in registry._locks
+
+    async def test_lock_not_evicted_while_waiter_queued(self):
+        """Lock stays in the registry while another coroutine is still waiting on it."""
+        registry = LockRegistry()
+        entered = asyncio.Event()
+
+        lock = registry.get(1)
+        async with lock:
+
+            async def waiter():
+                wlock = registry.get(1)
+                try:
+                    async with wlock:
+                        entered.set()
+                finally:
+                    registry.release(1)
+
+            task = asyncio.create_task(waiter())
+            await asyncio.sleep(0)
+            # Holder releases — should NOT evict because waiter is queued
+            registry.release(1)
+            assert 1 in registry._locks
+
+        # Let waiter finish
+        await entered.wait()
+        await task
+        assert 1 not in registry._locks
+
+    async def test_different_keys_independent(self):
+        """Different keys run concurrently and both get cleaned up independently."""
+        registry = LockRegistry()
+        order = []
+
+        async def work(key, label):
+            lock = registry.get(key)
+            try:
+                async with lock:
+                    order.append(f'{label}_start')
+                    await asyncio.sleep(0)
+                    order.append(f'{label}_end')
+            finally:
+                registry.release(key)
+
+        await asyncio.gather(work(1, 'a'), work(2, 'b'))
+        # Both should interleave since they use different keys
+        assert order == ['a_start', 'b_start', 'a_end', 'b_end']
+        assert 1 not in registry._locks
+        assert 2 not in registry._locks

--- a/tests/pipedrive/test_tasks.py
+++ b/tests/pipedrive/test_tasks.py
@@ -2,6 +2,7 @@
 Tests for Pipedrive sync tasks.
 """
 
+import asyncio
 from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
@@ -70,6 +71,38 @@ class TestSyncCompanyToPipedrive:
 
         # Should log warning, not call sync functions
         mock_sync_org.assert_not_called()
+
+    @patch('app.core.config.settings.sync_create_deals', True)
+    @patch('app.pipedrive.tasks.api.create_deal', new_callable=AsyncMock)
+    @patch('app.pipedrive.tasks.api.create_person', new_callable=AsyncMock)
+    @patch('app.pipedrive.tasks.api.create_organisation', new_callable=AsyncMock)
+    async def test_concurrent_sync_creates_only_one_deal(
+        self, mock_create_org, mock_create_person, mock_create_deal, db, test_company, test_contact, test_deal
+    ):
+        """Test that two concurrent sync_company_to_pipedrive calls for the same company
+        only create one PD deal, not two (the lock serializes them)."""
+        # Ensure no PD IDs are set so both would try to create
+        test_company.pd_org_id = None
+        test_contact.pd_person_id = None
+        test_deal.pd_deal_id = None
+        db.add(test_company)
+        db.add(test_contact)
+        db.add(test_deal)
+        db.commit()
+
+        mock_create_org.return_value = {'data': {'id': 100}}
+        mock_create_person.return_value = {'data': {'id': 200}}
+        mock_create_deal.return_value = {'data': {'id': 300}}
+
+        # Run two syncs concurrently — the lock should serialize them
+        await asyncio.gather(
+            sync_company_to_pipedrive(test_company.id),
+            sync_company_to_pipedrive(test_company.id),
+        )
+
+        # The first sync creates the deal; the second sync should see pd_deal_id already set
+        # and do a GET+PATCH (update) instead of POST (create)
+        assert mock_create_deal.call_count == 1
 
 
 class TestSyncOrganization:

--- a/tests/pipedrive/test_tasks.py
+++ b/tests/pipedrive/test_tasks.py
@@ -73,11 +73,30 @@ class TestSyncCompanyToPipedrive:
         mock_sync_org.assert_not_called()
 
     @patch('app.core.config.settings.sync_create_deals', True)
+    @patch('app.pipedrive.tasks.api.update_deal', new_callable=AsyncMock)
+    @patch('app.pipedrive.tasks.api.get_deal', new_callable=AsyncMock)
     @patch('app.pipedrive.tasks.api.create_deal', new_callable=AsyncMock)
+    @patch('app.pipedrive.tasks.api.update_person', new_callable=AsyncMock)
+    @patch('app.pipedrive.tasks.api.get_person', new_callable=AsyncMock)
     @patch('app.pipedrive.tasks.api.create_person', new_callable=AsyncMock)
+    @patch('app.pipedrive.tasks.api.update_organisation', new_callable=AsyncMock)
+    @patch('app.pipedrive.tasks.api.get_organisation', new_callable=AsyncMock)
     @patch('app.pipedrive.tasks.api.create_organisation', new_callable=AsyncMock)
     async def test_concurrent_sync_creates_only_one_deal(
-        self, mock_create_org, mock_create_person, mock_create_deal, db, test_company, test_contact, test_deal
+        self,
+        mock_create_org,
+        mock_get_org,
+        mock_update_org,
+        mock_create_person,
+        mock_get_person,
+        mock_update_person,
+        mock_create_deal,
+        mock_get_deal,
+        mock_update_deal,
+        db,
+        test_company,
+        test_contact,
+        test_deal,
     ):
         """Test that two concurrent sync_company_to_pipedrive calls for the same company
         only create one PD deal, not two (the lock serializes them)."""
@@ -90,8 +109,11 @@ class TestSyncCompanyToPipedrive:
         db.commit()
 
         mock_create_org.return_value = {'data': {'id': 100}}
+        mock_get_org.return_value = {'data': {'id': 100}}
         mock_create_person.return_value = {'data': {'id': 200}}
+        mock_get_person.return_value = {'data': {'id': 200}}
         mock_create_deal.return_value = {'data': {'id': 300}}
+        mock_get_deal.return_value = {'data': {'id': 300}}
 
         # Run two syncs concurrently for the locks to serialise them
         await asyncio.gather(

--- a/tests/pipedrive/test_tasks.py
+++ b/tests/pipedrive/test_tasks.py
@@ -81,7 +81,6 @@ class TestSyncCompanyToPipedrive:
     ):
         """Test that two concurrent sync_company_to_pipedrive calls for the same company
         only create one PD deal, not two (the lock serializes them)."""
-        # Ensure no PD IDs are set so both would try to create
         test_company.pd_org_id = None
         test_contact.pd_person_id = None
         test_deal.pd_deal_id = None
@@ -94,14 +93,14 @@ class TestSyncCompanyToPipedrive:
         mock_create_person.return_value = {'data': {'id': 200}}
         mock_create_deal.return_value = {'data': {'id': 300}}
 
-        # Run two syncs concurrently — the lock should serialize them
+        # Run two syncs concurrently for the locks to serialise them
         await asyncio.gather(
             sync_company_to_pipedrive(test_company.id),
             sync_company_to_pipedrive(test_company.id),
         )
 
         # The first sync creates the deal; the second sync should see pd_deal_id already set
-        # and do a GET+PATCH (update) instead of POST (create)
+        # and do a GET+PATCH
         assert mock_create_deal.call_count == 1
 
 

--- a/tests/tc2/test_tc2_integration.py
+++ b/tests/tc2/test_tc2_integration.py
@@ -1284,26 +1284,39 @@ class TestTC2DealCreation:
         assert updated_company is not None
         assert updated_company.tc2_status == 'live'
 
-    async def test_concurrent_process_tc_client_creates_only_one_deal(
-        self, db, test_admin, test_config, sample_tc_client_data
+    @patch('app.tc2.views.sync_company_to_pipedrive', new_callable=AsyncMock)
+    async def test_concurrent_webhooks_create_only_one_deal(
+        self, mock_sync, db, test_admin, test_config, sample_tc_client_data
     ):
-        """Test that two concurrent process_tc_client calls for the same cligency
-        only create one deal, not two (the cligency lock serialises them)."""
-        from app.tc2.views import _get_cligency_lock
+        """Test that two concurrent POST /tc2/callback/ requests for the same cligency
+        only create one deal, not two (exercises the real route with cligency lock)."""
+        from httpx import ASGITransport, AsyncClient
 
+        from app.main import app
+
+        sample_tc_client_data['model'] = 'Client'
         sample_tc_client_data['meta_agency']['status'] = 'trial'
         sample_tc_client_data['meta_agency']['created'] = datetime.now(timezone.utc).isoformat()
         sample_tc_client_data['meta_agency']['paid_invoice_count'] = 0
 
-        cligency_id = sample_tc_client_data['id']
+        webhook_data_1 = {
+            'events': [{'action': 'CREATED_A_CLIENT', 'verb': 'create', 'subject': sample_tc_client_data}],
+            '_request_time': 1234567890,
+        }
+        webhook_data_2 = {
+            'events': [{'action': 'EDITED_A_CLIENT', 'verb': 'edit', 'subject': sample_tc_client_data}],
+            '_request_time': 1234567891,
+        }
 
-        async def locked_process():
-            async with _get_cligency_lock(cligency_id):
-                tc_client = TCClient(**sample_tc_client_data)
-                await process_tc_client(tc_client, db, create_deal=True)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url='http://test') as ac:
+            responses = await asyncio.gather(
+                ac.post('/tc2/callback/', json=webhook_data_1),
+                ac.post('/tc2/callback/', json=webhook_data_2),
+            )
 
-        await asyncio.gather(locked_process(), locked_process())
+        assert all(r.status_code == 200 for r in responses)
 
+        db.expire_all()
         deals = db.exec(select(Deal).where(Deal.company_id.is_not(None))).all()
         assert len(deals) == 1
 

--- a/tests/tc2/test_tc2_integration.py
+++ b/tests/tc2/test_tc2_integration.py
@@ -2,6 +2,7 @@
 Integration tests for TC2 → Hermes → Pipedrive flow.
 """
 
+import asyncio
 import json
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
@@ -1282,6 +1283,29 @@ class TestTC2DealCreation:
         # Should not crash and should update successfully
         assert updated_company is not None
         assert updated_company.tc2_status == 'live'
+
+    async def test_concurrent_process_tc_client_creates_only_one_deal(
+        self, db, test_admin, test_config, sample_tc_client_data
+    ):
+        """Test that two concurrent process_tc_client calls for the same cligency
+        only create one deal, not two (the cligency lock serialises them)."""
+        from app.tc2.views import _get_cligency_lock
+
+        sample_tc_client_data['meta_agency']['status'] = 'trial'
+        sample_tc_client_data['meta_agency']['created'] = datetime.now(timezone.utc).isoformat()
+        sample_tc_client_data['meta_agency']['paid_invoice_count'] = 0
+
+        cligency_id = sample_tc_client_data['id']
+
+        async def locked_process():
+            async with _get_cligency_lock(cligency_id):
+                tc_client = TCClient(**sample_tc_client_data)
+                await process_tc_client(tc_client, db, create_deal=True)
+
+        await asyncio.gather(locked_process(), locked_process())
+
+        deals = db.exec(select(Deal).where(Deal.company_id.is_not(None))).all()
+        assert len(deals) == 1
 
 
 class TestTC2SyncableFields:

--- a/tests/tc2/test_tc2_integration.py
+++ b/tests/tc2/test_tc2_integration.py
@@ -8,8 +8,10 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from httpx import ASGITransport, AsyncClient
 from sqlmodel import select
 
+from app.main import app
 from app.main_app.models import Admin, Company, Config, Contact, Deal, Meeting, Pipeline, Stage
 from app.pipedrive.field_mappings import COMPANY_PD_FIELD_MAP, DEAL_PD_FIELD_MAP
 from app.pipedrive.tasks import sync_company_to_pipedrive
@@ -1290,10 +1292,6 @@ class TestTC2DealCreation:
     ):
         """Test that two concurrent POST /tc2/callback/ requests for the same cligency
         only create one deal, not two (exercises the real route with cligency lock)."""
-        from httpx import ASGITransport, AsyncClient
-
-        from app.main import app
-
         sample_tc_client_data['model'] = 'Client'
         sample_tc_client_data['meta_agency']['status'] = 'trial'
         sample_tc_client_data['meta_agency']['created'] = datetime.now(timezone.utc).isoformat()


### PR DESCRIPTION
**Issue number: Close #393**

### Technical description of changes
We now add a lock for each unique `cligency` in the API view and for each `Company` in the background task 

<details>
<summary>Load Testing </summary>

<img width="700" height="380" alt="image" src="https://github.com/user-attachments/assets/78a6b86a-8154-443e-9f22-1cf954cac5c1" />

Claude analysis from logfire data:

<img width="740" height="201" alt="image" src="https://github.com/user-attachments/assets/79570667-ab7e-4a3e-8cf2-6ad19b54acf5" />

</details>

### Manual testing
- [X] Created and ran the script to test the race condition mentioned on the issue (Fires `CREATED_A_CLIENT` and `EDITED_A_CLIENT` actions WH simultaneously)
- [X] No duplicate org or deals seen on PD

<img width="564" height="156" alt="image" src="https://github.com/user-attachments/assets/2e66361a-e1ca-47fb-b111-724267437c11" />
 
<img width="863" height="718" alt="image" src="https://github.com/user-attachments/assets/85601258-9469-4153-b5f6-00d2edf7826d" />



Check

* [x] Issue number added
* [x] The original issue clearly outlines the problem solved
* [x] Tests
* [ ] Coverage
* [x] Correct labels applied
