### PR TITLE
Set marketing_status=subscribed on new Pipedrive persons

### DIFF
--- a/app/pipedrive/tasks.py
+++ b/app/pipedrive/tasks.py
@@ -134,10 +134,7 @@ async def sync_person(contact_id: int):
 
     if not pd_person_id:
         try:
-            # Pipedrive defaults new persons to marketing_status=no_consent, which blocks
-            # our automated campaigns. Set to subscribed only on create — never on update,
-            # because Pipedrive only allows each status transition once and we must not
-            # overwrite a user's manual unsubscribe.
+            # Only on create — PD allows each status transition once, don't overwrite manual unsubscribes.
             person_data['marketing_status'] = 'subscribed'
             result = await api.create_person(person_data)
             new_pd_person_id = result['data']['id']

--- a/app/pipedrive/tasks.py
+++ b/app/pipedrive/tasks.py
@@ -134,6 +134,11 @@ async def sync_person(contact_id: int):
 
     if not pd_person_id:
         try:
+            # Pipedrive defaults new persons to marketing_status=no_consent, which blocks
+            # our automated campaigns. Set to subscribed only on create — never on update,
+            # because Pipedrive only allows each status transition once and we must not
+            # overwrite a user's manual unsubscribe.
+            person_data['marketing_status'] = 'subscribed'
             result = await api.create_person(person_data)
             new_pd_person_id = result['data']['id']
 

--- a/tests/pipedrive/test_tasks.py
+++ b/tests/pipedrive/test_tasks.py
@@ -316,6 +316,73 @@ class TestSyncPerson:
         db.refresh(test_contact)
         assert test_contact.pd_person_id == 2222
 
+    @patch('app.pipedrive.tasks.get_session')
+    @patch('app.pipedrive.tasks.api.create_person', new_callable=AsyncMock)
+    async def test_sync_person_create_sets_marketing_status_subscribed(
+        self, mock_create, mock_get_session, db, test_contact
+    ):
+        """Test that newly created persons have marketing_status=subscribed so
+        automated campaigns can send (otherwise PD defaults to no_consent)."""
+        test_contact.pd_person_id = None
+        db.add(test_contact)
+        db.commit()
+
+        mock_get_session.return_value = SessionMock(db)
+        mock_create.return_value = {'data': {'id': 3333}}
+
+        await sync_person(test_contact.id)
+
+        mock_create.assert_called_once()
+        payload = mock_create.call_args[0][0]
+        assert payload['marketing_status'] == 'subscribed'
+
+    @patch('app.pipedrive.tasks.get_session')
+    @patch('app.pipedrive.tasks.api.create_person', new_callable=AsyncMock)
+    @patch('app.pipedrive.tasks.api.get_person', new_callable=AsyncMock)
+    async def test_sync_person_recreate_after_404_sets_marketing_status(
+        self, mock_get, mock_create, mock_get_session, db, test_contact
+    ):
+        """Test that the recreate-after-404 path also sets marketing_status=subscribed."""
+        test_contact.pd_person_id = 999
+        db.add(test_contact)
+        db.commit()
+
+        mock_get_session.return_value = SessionMock(db)
+        mock_get.side_effect = Exception('404 Not Found')
+        mock_create.return_value = {'data': {'id': 4444}}
+
+        await sync_person(test_contact.id)
+
+        mock_create.assert_called_once()
+        payload = mock_create.call_args[0][0]
+        assert payload['marketing_status'] == 'subscribed'
+
+    @patch('app.pipedrive.tasks.get_session')
+    @patch('app.pipedrive.tasks.api.update_person', new_callable=AsyncMock)
+    @patch('app.pipedrive.tasks.api.get_person', new_callable=AsyncMock)
+    async def test_sync_person_update_does_not_set_marketing_status(
+        self, mock_get, mock_update, mock_get_session, db, test_contact
+    ):
+        """Test that updates to existing persons never send marketing_status.
+
+        Pipedrive only permits each status transition once; re-sending subscribed
+        on every sync would fail the second time a user manually unsubscribes.
+        """
+        test_contact.pd_person_id = 999
+        db.add(test_contact)
+        db.commit()
+
+        mock_get_session.return_value = SessionMock(db)
+        mock_get.return_value = {'data': {'id': 999, 'name': 'Old Name', 'marketing_status': 'unsubscribed'}}
+        mock_update.return_value = {'data': {'id': 999}}
+
+        await sync_person(test_contact.id)
+
+        # Either update was not called (no changes) or marketing_status not in the patch payload
+        if mock_update.called:
+            payload = mock_update.call_args[0][1]
+            assert 'marketing_status' not in payload
+
 
 class TestSyncDeal:
     """Test sync_deal function"""

--- a/tests/pipedrive/test_tasks.py
+++ b/tests/pipedrive/test_tasks.py
@@ -337,27 +337,6 @@ class TestSyncPerson:
         assert payload['marketing_status'] == 'subscribed'
 
     @patch('app.pipedrive.tasks.get_session')
-    @patch('app.pipedrive.tasks.api.create_person', new_callable=AsyncMock)
-    @patch('app.pipedrive.tasks.api.get_person', new_callable=AsyncMock)
-    async def test_sync_person_recreate_after_404_sets_marketing_status(
-        self, mock_get, mock_create, mock_get_session, db, test_contact
-    ):
-        """Test that the recreate-after-404 path also sets marketing_status=subscribed."""
-        test_contact.pd_person_id = 999
-        db.add(test_contact)
-        db.commit()
-
-        mock_get_session.return_value = SessionMock(db)
-        mock_get.side_effect = Exception('404 Not Found')
-        mock_create.return_value = {'data': {'id': 4444}}
-
-        await sync_person(test_contact.id)
-
-        mock_create.assert_called_once()
-        payload = mock_create.call_args[0][0]
-        assert payload['marketing_status'] == 'subscribed'
-
-    @patch('app.pipedrive.tasks.get_session')
     @patch('app.pipedrive.tasks.api.update_person', new_callable=AsyncMock)
     @patch('app.pipedrive.tasks.api.get_person', new_callable=AsyncMock)
     async def test_sync_person_update_does_not_set_marketing_status(
@@ -369,6 +348,7 @@ class TestSyncPerson:
         on every sync would fail the second time a user manually unsubscribes.
         """
         test_contact.pd_person_id = 999
+        test_contact.first_name = 'NewFirst'
         db.add(test_contact)
         db.commit()
 
@@ -378,10 +358,9 @@ class TestSyncPerson:
 
         await sync_person(test_contact.id)
 
-        # Either update was not called (no changes) or marketing_status not in the patch payload
-        if mock_update.called:
-            payload = mock_update.call_args[0][1]
-            assert 'marketing_status' not in payload
+        mock_update.assert_called_once()
+        payload = mock_update.call_args[0][1]
+        assert 'marketing_status' not in payload
 
 
 class TestSyncDeal:


### PR DESCRIPTION
**Issue number: Close #397**

### Technical description of changes
Set `marketing_status` to `subscribed` when creating a new person in Pipedrive. Without this, Pipedrive defaults to `no_consent` and our automated campaigns never send.

The field is only sent on create, not on update. Pipedrive allows each status transition only once per person, so re-sending it on every sync would overwrite a user's manual unsubscribe.


Check

* [x] Issue number added
* [ ] The original issue clearly outlines the problem solved
* [x] Tests
* [ ] Coverage
* [x] Correct labels applied