### PR TITLE
Link Google Meet CRM URL to PipeDrive deal (#403)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ __pycache__
 
 /.logfire/
 *.egg-info
+
+# Claude Code local config (skills, hooks, settings)
+.claude/

--- a/app/callbooker/process.py
+++ b/app/callbooker/process.py
@@ -12,7 +12,7 @@ from app.callbooker.utils import iso_8601_to_datetime
 from app.core.config import settings
 from app.core.database import DBSession
 from app.exceptions import MeetingBookingError
-from app.main_app.models import Admin, Company, Contact, Meeting
+from app.main_app.models import Admin, Company, Contact, Deal, Meeting
 
 logger = logging.getLogger('hermes.callbooker')
 
@@ -128,7 +128,11 @@ async def get_or_create_contact_company(event: CBSalesCall, db: DBSession) -> tu
 
 
 async def book_meeting(
-    company: Company, contact: Contact, event: CBSalesCall | CBSupportCall, db: DBSession
+    company: Company,
+    contact: Contact,
+    event: CBSalesCall | CBSupportCall,
+    db: DBSession,
+    deal: Deal | None = None,
 ) -> Meeting:
     """
     Book a meeting after checking:
@@ -154,7 +158,7 @@ async def book_meeting(
     meeting = _create_meeting_record(company.id, contact.id, event, meeting_start, meeting_end, db)
 
     try:
-        await _create_google_calendar_event(meeting, company, contact, admin, db)
+        await _create_google_calendar_event(meeting, company, contact, admin, db, deal=deal)
     except Exception as e:
         _delete_meeting_on_calendar_failure(meeting.id, db)
         raise e
@@ -218,7 +222,9 @@ def _delete_meeting_on_calendar_failure(meeting_id: int, db: DBSession) -> None:
         logger.info(f'Deleted meeting {meeting_id} due to Google Calendar failure')
 
 
-def _build_meeting_template_vars(company: Company, contact: Contact, admin: Admin, meeting_type: str) -> dict:
+def _build_meeting_template_vars(
+    company: Company, contact: Contact, admin: Admin, meeting_type: str, deal: Deal | None = None
+) -> dict:
     """Build template variables for meeting description"""
     template_vars = {
         'contact_first_name': contact.first_name or 'there',
@@ -235,7 +241,7 @@ def _build_meeting_template_vars(company: Company, contact: Contact, admin: Admi
                 'contact_phone': contact.phone,
                 'company_estimated_monthly_revenue': company.estimated_income,
                 'company_country': company.country,
-                'crm_url': company.pd_org_url or '',
+                'crm_url': (deal.pd_deal_url if deal else None) or company.pd_org_url or '',
             }
         )
 
@@ -243,11 +249,11 @@ def _build_meeting_template_vars(company: Company, contact: Contact, admin: Admi
 
 
 async def _create_google_calendar_event(
-    meeting: Meeting, company: Company, contact: Contact, admin: Admin, db: DBSession
+    meeting: Meeting, company: Company, contact: Contact, admin: Admin, db: DBSession, deal: Deal | None = None
 ) -> None:
     """Create Google Calendar event for the meeting"""
     meeting_template = MEETING_CONTENT_TEMPLATES[meeting.meeting_type]
-    template_vars = _build_meeting_template_vars(company, contact, admin, meeting.meeting_type)
+    template_vars = _build_meeting_template_vars(company, contact, admin, meeting.meeting_type, deal=deal)
 
     try:
         g_cal = AdminGoogleCalendar(admin_email=admin.email)

--- a/app/callbooker/views.py
+++ b/app/callbooker/views.py
@@ -38,7 +38,7 @@ async def sales_call(event: CBSalesCall, background_tasks: BackgroundTasks, db: 
     try:
         company, contact = await get_or_create_contact_company(event, db)
         deal = await get_or_create_deal(company, contact, db, status=Deal.STATUS_OPEN)
-        meeting = await book_meeting(company=company, contact=contact, event=event, db=db)
+        meeting = await book_meeting(company=company, contact=contact, event=event, db=db, deal=deal)
         meeting.deal_id = deal.id
         db.add(meeting)
         db.commit()

--- a/app/main_app/models.py
+++ b/app/main_app/models.py
@@ -306,6 +306,12 @@ class Deal(SQLModel, table=True):
     contact: Optional[Contact] = Relationship(back_populates='deals')
     meetings: List['Meeting'] = Relationship(back_populates='deal')
 
+    @property
+    def pd_deal_url(self):
+        if self.pd_deal_id:
+            return f'{settings.pd_base_url}/deal/{self.pd_deal_id}/'
+        return None
+
     def __str__(self):
         return self.name or f'Deal {self.id}'
 

--- a/app/pipedrive/tasks.py
+++ b/app/pipedrive/tasks.py
@@ -200,6 +200,12 @@ async def sync_deal(deal_id: int, only_syncable_deal_fields: bool = False):
             company = db.get(Company, deal.company_id)
         else:
             deal_data = _deal_to_pd_data(deal, db)
+            # pipeline/stage are excluded from _deal_to_pd_data (issue #399) so that
+            # updates never overwrite stages set by sales in Pipedrive. But new deals
+            # still need them so PD places them in the correct pipeline. Captured here
+            # while the session is open so as to put into deal_data only on the create path.
+            pd_pipeline_id = deal.pipeline.pd_pipeline_id if deal.pipeline else None
+            pd_stage_id = deal.stage.pd_stage_id if deal.stage else None
         pd_deal_id = deal.pd_deal_id
 
     if only_syncable_deal_fields:
@@ -231,12 +237,16 @@ async def sync_deal(deal_id: int, only_syncable_deal_fields: bool = False):
         except Exception as e:
             logger.error(f'Error updating deal {pd_deal_id}: {e}')
 
-    if not pd_deal_id:
+    else:
+        # We don't have a deal and creating one
         if not settings.sync_create_deals:
             logger.warning(f'Deal {deal_id} has no pd_deal_id, skipping sync (deal creation disabled)')
             return
 
         try:
+            # Only include pipeline/stage for creation (see comment above)
+            deal_data['pipeline_id'] = pd_pipeline_id
+            deal_data['stage_id'] = pd_stage_id
             result = await api.create_deal(deal_data)
             new_pd_deal_id = result['data']['id']
 

--- a/app/pipedrive/tasks.py
+++ b/app/pipedrive/tasks.py
@@ -366,8 +366,6 @@ def _deal_to_pd_data(deal: Deal, db) -> dict:
         'org_id': company.pd_org_id if company else None,
         'person_id': contact.pd_person_id if contact else None,
         'owner_id': deal.admin.pd_owner_id if deal.admin else None,
-        'pipeline_id': deal.pipeline.pd_pipeline_id if deal.pipeline else None,
-        'stage_id': deal.stage.pd_stage_id if deal.stage else None,
         'status': deal.status,
     }
 

--- a/patch.py
+++ b/patch.py
@@ -15,6 +15,7 @@ from sqlmodel import select
 
 from app.core.database import get_session
 from app.pipedrive import api
+from app.main_app.models import Stage
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger('hermes.patch')
@@ -561,6 +562,45 @@ async def reassign_deals_with_invalid_admin(db):
             deals_updated += 1
 
     print(f'Updated {deals_updated} deals')
+
+
+@command
+async def insert_missing_stages(db):
+    """
+    Fetch all stages from Pipedrive and insert any that are missing from Hermes.
+
+    Hermes only learns about stages via system_setup or PD stage-entity webhooks.
+    If a stage was created in PD after initial setup and no stage webhook was sent,
+    it won't exist in Hermes. Deal webhooks referencing that stage_id then silently
+    fail to update the deal's stage.
+
+    This patch fetches every stage across all pipelines from the PD API and inserts
+    any that don't already exist in the Hermes stage table.
+    """
+
+    existing = {s.pd_stage_id for s in db.exec(select(Stage)).all()}
+    print(f'{len(existing)} stages already in Hermes')
+
+    pipelines = await api.pipedrive_request('pipelines', method='GET')
+    pd_pipelines = pipelines.get('data', [])
+    print(f'Found {len(pd_pipelines)} pipelines in Pipedrive')
+
+    inserted = []
+    for pd_pipeline in pd_pipelines:
+        result = await api.pipedrive_request('stages', method='GET', query_params={'pipeline_id': pd_pipeline['id']})
+        pd_stages = result.get('data', [])
+
+        for pd_stage in pd_stages:
+            if pd_stage['id'] not in existing:
+                stage = Stage(pd_stage_id=pd_stage['id'], name=pd_stage['name'])
+                db.add(stage)
+                inserted.append((pd_stage['id'], pd_stage['name'], pd_pipeline['name']))
+                print(f'  INSERT stage {pd_stage["id"]}: {pd_stage["name"]} (pipeline: {pd_pipeline["name"]})')
+
+    if inserted:
+        print(f'\nInserted {len(inserted)} missing stages')
+    else:
+        print('\nNo missing stages found')
 
 
 @click.command()

--- a/patch.py
+++ b/patch.py
@@ -582,13 +582,13 @@ async def insert_missing_stages(db):
     print(f'{len(existing)} stages already in Hermes')
 
     pipelines = await api.pipedrive_request('pipelines', method='GET')
-    pd_pipelines = pipelines.get('data', [])
+    pd_pipelines = pipelines.get('data') or []
     print(f'Found {len(pd_pipelines)} pipelines in Pipedrive')
 
     inserted = []
     for pd_pipeline in pd_pipelines:
         result = await api.pipedrive_request('stages', method='GET', query_params={'pipeline_id': pd_pipeline['id']})
-        pd_stages = result.get('data', [])
+        pd_stages = result.get('data') or []
 
         for pd_stage in pd_stages:
             if pd_stage['id'] not in existing:

--- a/patch.py
+++ b/patch.py
@@ -14,8 +14,8 @@ import click
 from sqlmodel import select
 
 from app.core.database import get_session
-from app.pipedrive import api
 from app.main_app.models import Stage
+from app.pipedrive import api
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger('hermes.patch')

--- a/tests/callbooker/test_process_coverage.py
+++ b/tests/callbooker/test_process_coverage.py
@@ -65,6 +65,70 @@ class TestCallbookerProcessEdgeCases:
         assert meeting is not None
         assert len(session_open) == 0
 
+    @patch('app.callbooker.process.AdminGoogleCalendar')
+    @patch('app.callbooker.process.check_gcal_open_slots', new_callable=AsyncMock)
+    async def test_crm_url_uses_deal_when_synced(
+        self, mock_check_gcal, mock_gcal_class, db, test_admin, test_company, test_contact, test_deal
+    ):
+        """Sales meeting CRM URL links to the PipeDrive deal when the deal has a pd_deal_id"""
+        mock_check_gcal.return_value = True
+        test_deal.pd_deal_id = 555
+        db.add(test_deal)
+        db.commit()
+
+        captured = {}
+        mock_gcal_class.return_value.create_cal_event = lambda *a, **kw: captured.update(kw)
+
+        future_dt = datetime.now(utc) + timedelta(days=1)
+        event = CBSalesCall(
+            admin_id=test_admin.id,
+            name='John Doe',
+            email='john@example.com',
+            company_name='Test Company',
+            country='GB',
+            estimated_income=1000,
+            currency='GBP',
+            price_plan='payg',
+            meeting_dt=future_dt,
+        )
+
+        await book_meeting(test_company, test_contact, event, db, deal=test_deal)
+
+        assert '/deal/555/' in captured['description']
+
+    @patch('app.callbooker.process.AdminGoogleCalendar')
+    @patch('app.callbooker.process.check_gcal_open_slots', new_callable=AsyncMock)
+    async def test_crm_url_falls_back_to_org_when_deal_not_synced(
+        self, mock_check_gcal, mock_gcal_class, db, test_admin, test_company, test_contact, test_deal
+    ):
+        """Sales meeting CRM URL falls back to the org URL when the deal has no pd_deal_id"""
+        mock_check_gcal.return_value = True
+        test_deal.pd_deal_id = None
+        test_company.pd_org_id = 777
+        db.add(test_deal)
+        db.add(test_company)
+        db.commit()
+
+        captured = {}
+        mock_gcal_class.return_value.create_cal_event = lambda *a, **kw: captured.update(kw)
+
+        future_dt = datetime.now(utc) + timedelta(days=1)
+        event = CBSalesCall(
+            admin_id=test_admin.id,
+            name='John Doe',
+            email='john@example.com',
+            company_name='Test Company',
+            country='GB',
+            estimated_income=1000,
+            currency='GBP',
+            price_plan='payg',
+            meeting_dt=future_dt,
+        )
+
+        await book_meeting(test_company, test_contact, event, db, deal=test_deal)
+
+        assert '/organization/777/' in captured['description']
+
     @patch('app.callbooker.process.check_gcal_open_slots')
     async def test_sales_call_admin_not_found_raises_error(
         self, mock_check_gcal, client, db, test_company, test_pipeline, test_stage, test_config

--- a/tests/pipedrive/test_tasks.py
+++ b/tests/pipedrive/test_tasks.py
@@ -452,6 +452,28 @@ class TestSyncDeal:
         assert test_deal.pd_deal_id == 4444
 
     @patch('app.core.config.settings.sync_create_deals', True)
+    @patch('app.pipedrive.tasks.get_session')
+    @patch('app.pipedrive.tasks.api.create_deal', new_callable=AsyncMock)
+    async def test_sync_deal_create_includes_pipeline_and_stage(self, mock_create, mock_get_session, db, test_deal):
+        """New deals sent to Pipedrive must include pipeline_id and stage_id
+        so they land in the correct pipeline (PAYG/Startup/Enterprise)."""
+        test_deal.pd_deal_id = None
+        db.add(test_deal)
+        db.commit()
+
+        mock_get_session.return_value = SessionMock(db)
+        mock_create.return_value = {'data': {'id': 5555}}
+
+        await sync_deal(test_deal.id)
+
+        mock_create.assert_called_once()
+        payload = mock_create.call_args[0][0]
+        assert 'pipeline_id' in payload, 'create_deal payload must include pipeline_id'
+        assert payload['pipeline_id'] == test_deal.pipeline.pd_pipeline_id
+        assert 'stage_id' in payload, 'create_deal payload must include stage_id'
+        assert payload['stage_id'] == test_deal.stage.pd_stage_id
+
+    @patch('app.core.config.settings.sync_create_deals', True)
     @patch('app.pipedrive.tasks.api.create_deal', new_callable=AsyncMock)
     @patch('app.pipedrive.tasks.api.update_deal', new_callable=AsyncMock)
     @patch('app.pipedrive.tasks.api.create_organisation', new_callable=AsyncMock)

--- a/tests/pipedrive/test_tasks.py
+++ b/tests/pipedrive/test_tasks.py
@@ -403,6 +403,29 @@ class TestSyncDeal:
         assert test_deal.pd_deal_id == 999
 
     @patch('app.pipedrive.tasks.get_session')
+    @patch('app.pipedrive.tasks.api.update_deal', new_callable=AsyncMock)
+    @patch('app.pipedrive.tasks.api.get_deal', new_callable=AsyncMock)
+    async def test_sync_deal_never_sends_stage_or_pipeline(
+        self, mock_get, mock_update, mock_get_session, db, test_deal
+    ):
+        """Syncing a deal must never overwrite stage_id or pipeline_id in Pipedrive (issue #399)"""
+        test_deal.pd_deal_id = 999
+        db.add(test_deal)
+        db.commit()
+
+        mock_get_session.return_value = SessionMock(db)
+        mock_get.return_value = {
+            'data': {'title': 'Different Title', 'status': 'open', 'stage_id': 55, 'pipeline_id': 99}
+        }
+
+        await sync_deal(test_deal.id)
+
+        mock_update.assert_called_once()
+        changed_fields = mock_update.call_args[0][1]
+        assert 'stage_id' not in changed_fields
+        assert 'pipeline_id' not in changed_fields
+
+    @patch('app.pipedrive.tasks.get_session')
     @patch('app.pipedrive.tasks.api.get_deal', new_callable=AsyncMock)
     async def test_sync_deal_update_non_404_error(self, mock_get, mock_get_session, db, test_deal):
         """Test deal update with non-404 error logs but doesn't clear ID"""
@@ -849,6 +872,13 @@ class TestDealToPDData:
 
         # Custom fields
         assert 'custom_fields' in result
+
+    def test_deal_to_pd_data_excludes_stage_and_pipeline(self, db, test_deal):
+        """Hermes must never overwrite deal stage or pipeline in Pipedrive (issue #399)"""
+        result = _deal_to_pd_data(test_deal, db)
+
+        assert 'stage_id' not in result
+        assert 'pipeline_id' not in result
 
     def test_deal_to_pd_data_handles_missing_contact(self, db, test_deal):
         """Test that deal data handles deals without a contact"""

--- a/tests/pipedrive/test_tasks.py
+++ b/tests/pipedrive/test_tasks.py
@@ -845,8 +845,6 @@ class TestDealToPDData:
         # Foreign key references
         assert 'org_id' in result
         assert 'person_id' in result
-        assert 'pipeline_id' in result
-        assert 'stage_id' in result
         assert 'owner_id' in result
 
         # Custom fields
@@ -1022,8 +1020,6 @@ class TestDataConversionHelpers:
         assert 'title' in result
         assert 'org_id' in result
         assert 'owner_id' in result
-        assert 'pipeline_id' in result
-        assert 'stage_id' in result
         assert 'status' in result
         assert 'custom_fields' in result
 

--- a/tests/pipedrive/test_tasks.py
+++ b/tests/pipedrive/test_tasks.py
@@ -403,29 +403,6 @@ class TestSyncDeal:
         assert test_deal.pd_deal_id == 999
 
     @patch('app.pipedrive.tasks.get_session')
-    @patch('app.pipedrive.tasks.api.update_deal', new_callable=AsyncMock)
-    @patch('app.pipedrive.tasks.api.get_deal', new_callable=AsyncMock)
-    async def test_sync_deal_never_sends_stage_or_pipeline(
-        self, mock_get, mock_update, mock_get_session, db, test_deal
-    ):
-        """Syncing a deal must never overwrite stage_id or pipeline_id in Pipedrive (issue #399)"""
-        test_deal.pd_deal_id = 999
-        db.add(test_deal)
-        db.commit()
-
-        mock_get_session.return_value = SessionMock(db)
-        mock_get.return_value = {
-            'data': {'title': 'Different Title', 'status': 'open', 'stage_id': 55, 'pipeline_id': 99}
-        }
-
-        await sync_deal(test_deal.id)
-
-        mock_update.assert_called_once()
-        changed_fields = mock_update.call_args[0][1]
-        assert 'stage_id' not in changed_fields
-        assert 'pipeline_id' not in changed_fields
-
-    @patch('app.pipedrive.tasks.get_session')
     @patch('app.pipedrive.tasks.api.get_deal', new_callable=AsyncMock)
     async def test_sync_deal_update_non_404_error(self, mock_get, mock_get_session, db, test_deal):
         """Test deal update with non-404 error logs but doesn't clear ID"""
@@ -872,13 +849,6 @@ class TestDealToPDData:
 
         # Custom fields
         assert 'custom_fields' in result
-
-    def test_deal_to_pd_data_excludes_stage_and_pipeline(self, db, test_deal):
-        """Hermes must never overwrite deal stage or pipeline in Pipedrive (issue #399)"""
-        result = _deal_to_pd_data(test_deal, db)
-
-        assert 'stage_id' not in result
-        assert 'pipeline_id' not in result
 
     def test_deal_to_pd_data_handles_missing_contact(self, db, test_deal):
         """Test that deal data handles deals without a contact"""

--- a/tests/tc2/test_tc2_integration.py
+++ b/tests/tc2/test_tc2_integration.py
@@ -281,6 +281,79 @@ class TestTC2Integration:
             url = kwargs.get('url', '')
             assert not (method == 'POST' and 'deals' in url), 'create_deal should not be called when update returns 404'
 
+    @patch('httpx.AsyncClient.request')
+    async def test_tc2_sync_never_overwrites_deal_stage_or_pipeline(
+        self,
+        mock_request,
+        client,
+        db,
+        test_admin,
+        test_pipeline,
+        test_stage,
+        sample_tc_client_data,
+    ):
+        """
+        End-to-end: TC2 webhook for an unpaid agency triggers a full deal sync.
+        Even when PD reports a different stage_id/pipeline_id (i.e. sales moved the deal),
+        the PATCH to PD must never include stage_id or pipeline_id. (issue #399)
+        """
+        pd_deal_id = 888
+
+        async def request_side_effect(*args, **kwargs):
+            method = kwargs.get('method')
+            url = kwargs.get('url', '')
+            if method == 'GET' and 'deals' in url:
+                return create_mock_response(
+                    {
+                        'data': {
+                            'id': pd_deal_id,
+                            'title': 'Test Agency',
+                            'status': 'open',
+                            'stage_id': 55,
+                            'pipeline_id': 99,
+                        }
+                    }
+                )
+            return create_mock_response({'data': {'id': 999}})
+
+        mock_request.side_effect = request_side_effect
+        sample_tc_client_data['model'] = 'Client'
+        sample_tc_client_data['meta_agency']['paid_invoice_count'] = 0
+
+        webhook_data = {
+            'events': [{'action': 'UPDATE', 'verb': 'update', 'subject': sample_tc_client_data}],
+            '_request_time': 1234567890,
+        }
+
+        r = client.post(client.app.url_path_for('tc2-callback'), json=webhook_data)
+        assert r.status_code == 200
+
+        company = db.exec(select(Company).where(Company.tc2_cligency_id == 123)).first()
+        contact = db.exec(select(Contact).where(Contact.company_id == company.id)).first()
+        db.create(
+            Deal(
+                name='Test Agency',
+                company_id=company.id,
+                contact_id=contact.id,
+                admin_id=test_admin.id,
+                pipeline_id=test_pipeline.id,
+                stage_id=test_stage.id,
+                status=Deal.STATUS_OPEN,
+                pd_deal_id=pd_deal_id,
+            )
+        )
+
+        await sync_company_to_pipedrive(company.id)
+
+        for call in mock_request.call_args_list:
+            kwargs = call.kwargs
+            method = kwargs.get('method')
+            url = kwargs.get('url', '')
+            if method == 'PATCH' and 'deals' in url:
+                body = kwargs.get('json', {})
+                assert 'stage_id' not in body, 'Hermes must never overwrite deal stage in Pipedrive'
+                assert 'pipeline_id' not in body, 'Hermes must never overwrite deal pipeline in Pipedrive'
+
     async def test_narc_company_not_synced_to_pipedrive(self, db, test_admin, sample_tc_client_data):
         """Test that NARC companies are purged from Pipedrive"""
         sample_tc_client_data['meta_agency']['narc'] = True

--- a/tests/tc2/test_tc2_integration.py
+++ b/tests/tc2/test_tc2_integration.py
@@ -345,14 +345,15 @@ class TestTC2Integration:
 
         await sync_company_to_pipedrive(company.id)
 
-        for call in mock_request.call_args_list:
-            kwargs = call.kwargs
-            method = kwargs.get('method')
-            url = kwargs.get('url', '')
-            if method == 'PATCH' and 'deals' in url:
-                body = kwargs.get('json', {})
-                assert 'stage_id' not in body, 'Hermes must never overwrite deal stage in Pipedrive'
-                assert 'pipeline_id' not in body, 'Hermes must never overwrite deal pipeline in Pipedrive'
+        deal_patches = [
+            call
+            for call in mock_request.call_args_list
+            if call.kwargs.get('method') == 'PATCH' and 'deals' in call.kwargs.get('url', '')
+        ]
+        assert len(deal_patches) == 1, f'Expected exactly 1 deal PATCH, got {len(deal_patches)}'
+        body = deal_patches[0].kwargs.get('json', {})
+        assert 'stage_id' not in body, 'Hermes must never overwrite deal stage in Pipedrive'
+        assert 'pipeline_id' not in body, 'Hermes must never overwrite deal pipeline in Pipedrive'
 
     async def test_narc_company_not_synced_to_pipedrive(self, db, test_admin, sample_tc_client_data):
         """Test that NARC companies are purged from Pipedrive"""


### PR DESCRIPTION
**Issue number: Close #403**

### Technical description of changes

Sales books a call, gets a calendar invite. That invite carried a link into PipeDrive — but it dumped them on the company page, not the deal they actually need. Wrong context, every time.

Now the link goes straight to the deal. If the deal isn't in PipeDrive yet, it falls back to the company link, so nothing breaks.

Sales-only. Support invites are untouched.

Check

* [x] Issue number added
* [x] The original issue clearly outlines the problem solved
* [x] Tests
* [x] Coverage
* [x] Correct labels applied