### PR TITLE
Sync receive_marketing_emails from TC2 to Pipedrive

### DIFF
--- a/app/main_app/models.py
+++ b/app/main_app/models.py
@@ -176,6 +176,7 @@ class Company(SQLModel, table=True):
     has_booked_call: bool = Field(default=False)
     has_signed_up: bool = Field(default=False)
     narc: bool = Field(default=False)
+    receive_marketing_emails: bool = Field(default=False)
     is_deleted: bool = Field(default=False)
 
     # Fields synced to/from Pipedrive

--- a/app/pipedrive/field_mappings.py
+++ b/app/pipedrive/field_mappings.py
@@ -37,6 +37,11 @@ _DEFAULT_COMPANY_PD_FIELD_MAP = {
     'gclid_expiry_dt': '21685501a4a4fc347f609adcafc9908d774034f9',
     'email_confirmed_dt': '35d6e7ef145f1966d2a53fe7c02c87efd1455587',
     'card_saved_dt': '90af5597493bd9a2a0637df22fb29038cbb2a2db',
+    # Placeholder key: run `python create_pipedrive_fields.py` to create the organization field in
+    # Pipedrive, then `make setup-fields` to fetch its key into field_mappings_override.py, and
+    # replace this value. Until then _company_to_org_data skips any 'TODO_'-prefixed id, so it is
+    # never sent to Pipedrive.
+    'receive_marketing_emails': 'TODO_PD_FIELD_ID_receive_marketing_emails',
 }
 
 _DEFAULT_DEAL_PD_FIELD_MAP = {

--- a/app/pipedrive/field_mappings.py
+++ b/app/pipedrive/field_mappings.py
@@ -37,10 +37,15 @@ _DEFAULT_COMPANY_PD_FIELD_MAP = {
     'gclid_expiry_dt': '21685501a4a4fc347f609adcafc9908d774034f9',
     'email_confirmed_dt': '35d6e7ef145f1966d2a53fe7c02c87efd1455587',
     'card_saved_dt': '90af5597493bd9a2a0637df22fb29038cbb2a2db',
-    # Placeholder key — MUST be replaced before deploy: run `python create_pipedrive_fields.py` to
-    # create the organization field in Pipedrive, then `make setup-fields` to fetch its key into
-    # field_mappings_override.py, and replace this value with the real key.
-    'receive_marketing_emails': 'TODO_PD_FIELD_ID_receive_marketing_emails',
+    'receive_marketing_emails': 'f96180f45c324d57c3dd42b02a9ec511311e9638',
+}
+
+# Pipedrive single-option (enum) IDs for bool fields — option IDs are per Pipedrive account.
+_DEFAULT_COMPANY_PD_ENUM_OPTION_MAP = {
+    'receive_marketing_emails': {
+        'yes': 505,
+        'no': 506,
+    },
 }
 
 _DEFAULT_DEAL_PD_FIELD_MAP = {
@@ -65,6 +70,7 @@ _DEFAULT_CONTACT_PD_FIELD_MAP = {
 COMPANY_PD_FIELD_MAP = _DEFAULT_COMPANY_PD_FIELD_MAP.copy()
 DEAL_PD_FIELD_MAP = _DEFAULT_DEAL_PD_FIELD_MAP.copy()
 CONTACT_PD_FIELD_MAP = _DEFAULT_CONTACT_PD_FIELD_MAP.copy()
+COMPANY_PD_ENUM_OPTION_MAP = {field: options.copy() for field, options in _DEFAULT_COMPANY_PD_ENUM_OPTION_MAP.items()}
 
 override_path = PROJECT_ROOT / 'field_mappings_override.py'
 
@@ -84,5 +90,12 @@ if os.path.exists(override_path):
 
         if hasattr(field_mappings_override, 'CONTACT_PD_FIELD_MAP'):
             CONTACT_PD_FIELD_MAP.update(field_mappings_override.CONTACT_PD_FIELD_MAP)
+
+        if hasattr(field_mappings_override, 'COMPANY_PD_ENUM_OPTION_MAP'):
+            for field_name, options in field_mappings_override.COMPANY_PD_ENUM_OPTION_MAP.items():
+                if field_name in COMPANY_PD_ENUM_OPTION_MAP:
+                    COMPANY_PD_ENUM_OPTION_MAP[field_name].update(options)
+                else:
+                    COMPANY_PD_ENUM_OPTION_MAP[field_name] = options.copy()
 
         logger.info(f'Loaded field mapping overrides from {override_path}')

--- a/app/pipedrive/field_mappings.py
+++ b/app/pipedrive/field_mappings.py
@@ -37,10 +37,9 @@ _DEFAULT_COMPANY_PD_FIELD_MAP = {
     'gclid_expiry_dt': '21685501a4a4fc347f609adcafc9908d774034f9',
     'email_confirmed_dt': '35d6e7ef145f1966d2a53fe7c02c87efd1455587',
     'card_saved_dt': '90af5597493bd9a2a0637df22fb29038cbb2a2db',
-    # Placeholder key: run `python create_pipedrive_fields.py` to create the organization field in
-    # Pipedrive, then `make setup-fields` to fetch its key into field_mappings_override.py, and
-    # replace this value. Until then _company_to_org_data skips any 'TODO_'-prefixed id, so it is
-    # never sent to Pipedrive.
+    # Placeholder key — MUST be replaced before deploy: run `python create_pipedrive_fields.py` to
+    # create the organization field in Pipedrive, then `make setup-fields` to fetch its key into
+    # field_mappings_override.py, and replace this value with the real key.
     'receive_marketing_emails': 'TODO_PD_FIELD_ID_receive_marketing_emails',
 }
 

--- a/app/pipedrive/process.py
+++ b/app/pipedrive/process.py
@@ -137,7 +137,9 @@ class OrganisationProcessor(PipedriveObjProcessor):
         return [
             f
             for f in list(COMPANY_PD_FIELD_MAP.keys())
-            if f not in ['hermes_id', 'bdr_person_id', 'support_person_id', 'tc2_cligency_url']
+            # receive_marketing_emails is TC2-authoritative; Pipedrive must not write it back.
+            if f
+            not in ['hermes_id', 'bdr_person_id', 'support_person_id', 'tc2_cligency_url', 'receive_marketing_emails']
         ]
 
     async def _add_obj(self, pd_obj: Organisation) -> Company:

--- a/app/pipedrive/tasks.py
+++ b/app/pipedrive/tasks.py
@@ -320,6 +320,10 @@ def _company_to_org_data(company: Company) -> dict:
 
     # Map fields to Pipedrive field IDs
     for field_name, pd_field_id in COMPANY_PD_FIELD_MAP.items():
+        # Skip fields whose Pipedrive id has not been provisioned yet (placeholder). Sending an
+        # unknown custom-field key would make Pipedrive reject the whole organization sync.
+        if pd_field_id.startswith('TODO_'):
+            continue
         if field_name == 'hermes_id':
             value = company.id
         elif field_name == 'tc2_cligency_url':
@@ -328,8 +332,11 @@ def _company_to_org_data(company: Company) -> dict:
             value = getattr(company, field_name, None)
 
         if value is not None and value != '':
+            # Convert booleans to Yes/No text (Pipedrive has no native boolean field type)
+            if isinstance(value, bool):
+                value = 'Yes' if value else 'No'
             # Convert datetime to ISO date string
-            if isinstance(value, datetime):
+            elif isinstance(value, datetime):
                 value = value.date().isoformat()
             # Convert integers to strings for hermes_id and paid_invoice_count (text fields in Pipedrive)
             elif field_name in ('hermes_id', 'paid_invoice_count') and isinstance(value, int):

--- a/app/pipedrive/tasks.py
+++ b/app/pipedrive/tasks.py
@@ -8,7 +8,12 @@ from app.core.database import get_session
 from app.core.locks import RedisLockRegistry
 from app.main_app.models import Company, Contact, Deal, Meeting
 from app.pipedrive import api
-from app.pipedrive.field_mappings import COMPANY_PD_FIELD_MAP, CONTACT_PD_FIELD_MAP, DEAL_PD_FIELD_MAP
+from app.pipedrive.field_mappings import (
+    COMPANY_PD_ENUM_OPTION_MAP,
+    COMPANY_PD_FIELD_MAP,
+    CONTACT_PD_FIELD_MAP,
+    DEAL_PD_FIELD_MAP,
+)
 
 logger = logging.getLogger('hermes.pipedrive')
 
@@ -303,6 +308,20 @@ async def purge_company_from_pipedrive(company_id: int):
             logger.error(f'Error purging company {company_id}: {e}', exc_info=True)
 
 
+def _bool_to_pd_enum_option(field_name: str, value: bool) -> int | None:
+    """Map a Hermes bool to a Pipedrive single-option (enum) field option ID."""
+    options = COMPANY_PD_ENUM_OPTION_MAP.get(field_name)
+    if not options:
+        return None
+    if value:
+        option_id = options.get('yes')
+    else:
+        option_id = options.get('no')
+    if option_id is None:
+        return None
+    return int(option_id)
+
+
 def _company_to_org_data(company: Company) -> dict:
     """Convert Company model to Pipedrive organization data"""
     data = {
@@ -327,9 +346,12 @@ def _company_to_org_data(company: Company) -> dict:
         else:
             value = getattr(company, field_name, None)
 
-        # Pipedrive has no native boolean field type, so store booleans as Yes/No text.
+        # Pipedrive has no native boolean field type — use enum option IDs where configured.
         if isinstance(value, bool):
-            value = 'Yes' if value else 'No'
+            enum_option_id = _bool_to_pd_enum_option(field_name, value)
+            if enum_option_id is None:
+                continue
+            value = enum_option_id
 
         if value is not None and value != '':
             # Convert datetime to ISO date string

--- a/app/pipedrive/tasks.py
+++ b/app/pipedrive/tasks.py
@@ -320,10 +320,6 @@ def _company_to_org_data(company: Company) -> dict:
 
     # Map fields to Pipedrive field IDs
     for field_name, pd_field_id in COMPANY_PD_FIELD_MAP.items():
-        # Skip fields whose Pipedrive id has not been provisioned yet (placeholder). Sending an
-        # unknown custom-field key would make Pipedrive reject the whole organization sync.
-        if pd_field_id.startswith('TODO_'):
-            continue
         if field_name == 'hermes_id':
             value = company.id
         elif field_name == 'tc2_cligency_url':
@@ -331,12 +327,13 @@ def _company_to_org_data(company: Company) -> dict:
         else:
             value = getattr(company, field_name, None)
 
+        # Pipedrive has no native boolean field type, so store booleans as Yes/No text.
+        if isinstance(value, bool):
+            value = 'Yes' if value else 'No'
+
         if value is not None and value != '':
-            # Convert booleans to Yes/No text (Pipedrive has no native boolean field type)
-            if isinstance(value, bool):
-                value = 'Yes' if value else 'No'
             # Convert datetime to ISO date string
-            elif isinstance(value, datetime):
+            if isinstance(value, datetime):
                 value = value.date().isoformat()
             # Convert integers to strings for hermes_id and paid_invoice_count (text fields in Pipedrive)
             elif field_name in ('hermes_id', 'paid_invoice_count') and isinstance(value, int):

--- a/app/tc2/models.py
+++ b/app/tc2/models.py
@@ -36,6 +36,7 @@ class _TCAgency(BaseModel):
     created: datetime = Field(exclude=True)
     price_plan: str
     narc: Optional[bool] = False
+    receive_marketing_emails: Optional[bool] = False
     signup_questionnaire: Optional[str] = None
     pay0_dt: Optional[datetime] = None
     pay1_dt: Optional[datetime] = None

--- a/app/tc2/process.py
+++ b/app/tc2/process.py
@@ -37,8 +37,6 @@ def _update_syncable_fields(company: Company, tc_client: TCClient):
     for field in COMPANY_SYNCABLE_FIELDS:
         tc2_field = 'status' if field == 'tc2_status' else field
         value = getattr(tc_client.meta_agency, tc2_field)
-        if field in ('narc', 'receive_marketing_emails'):
-            value = bool(value)
         setattr(company, field, value)
 
 

--- a/app/tc2/process.py
+++ b/app/tc2/process.py
@@ -22,6 +22,7 @@ COMPANY_SYNCABLE_FIELDS = {
     'gclid_expiry_dt',
     'tc2_status',
     'narc',
+    'receive_marketing_emails',
     'paid_invoice_count',
     'signup_questionnaire',
 }
@@ -36,6 +37,8 @@ def _update_syncable_fields(company: Company, tc_client: TCClient):
     for field in COMPANY_SYNCABLE_FIELDS:
         tc2_field = 'status' if field == 'tc2_status' else field
         value = getattr(tc_client.meta_agency, tc2_field)
+        if field in ('narc', 'receive_marketing_emails'):
+            value = bool(value)
         setattr(company, field, value)
 
 
@@ -151,6 +154,7 @@ async def process_tc_client(tc_client: TCClient, db: DBSession, create_deal: boo
             paid_invoice_count=tc_client.meta_agency.paid_invoice_count,
             price_plan=tc_client.meta_agency.price_plan,
             narc=tc_client.meta_agency.narc or False,
+            receive_marketing_emails=tc_client.meta_agency.receive_marketing_emails or False,
             pay0_dt=tc_client.meta_agency.pay0_dt,
             pay1_dt=tc_client.meta_agency.pay1_dt,
             pay3_dt=tc_client.meta_agency.pay3_dt,

--- a/create_pipedrive_fields.py
+++ b/create_pipedrive_fields.py
@@ -36,6 +36,7 @@ ORGANIZATION_FIELDS = [
     {'name': 'gclid_expiry_dt', 'field_type': 'date'},
     {'name': 'email_confirmed_dt', 'field_type': 'date'},
     {'name': 'card_saved_dt', 'field_type': 'date'},
+    {'name': 'receive_marketing_emails', 'field_type': 'text'},
 ]
 
 PERSON_FIELDS = [

--- a/create_pipedrive_fields.py
+++ b/create_pipedrive_fields.py
@@ -36,7 +36,7 @@ ORGANIZATION_FIELDS = [
     {'name': 'gclid_expiry_dt', 'field_type': 'date'},
     {'name': 'email_confirmed_dt', 'field_type': 'date'},
     {'name': 'card_saved_dt', 'field_type': 'date'},
-    {'name': 'receive_marketing_emails', 'field_type': 'text'},
+    {'name': 'receive_marketing_emails', 'field_type': 'enum', 'options': [{'label': 'Yes'}, {'label': 'No'}]},
 ]
 
 PERSON_FIELDS = [
@@ -71,6 +71,8 @@ async def create_field(client: httpx.AsyncClient, entity_type: str, field_data: 
         'name': field_data['name'],
         'field_type': field_data['field_type'],
     }
+    if field_data.get('options'):
+        payload['options'] = field_data['options']
 
     try:
         response = await client.post(url, json=payload, params=params)
@@ -80,6 +82,8 @@ async def create_field(client: httpx.AsyncClient, entity_type: str, field_data: 
         if result.get('success'):
             field_id = result['data']['key']
             print(f'✓ Created {entity_type} field: {field_data["name"]} (ID: {field_id})')
+            for option in result['data'].get('options') or []:
+                print(f'    option "{option.get("label")}": id={option.get("id")}')
         else:
             print(f'✗ Failed to create {entity_type} field: {field_data["name"]} - {result}')
 

--- a/field_mappings_override.example.py
+++ b/field_mappings_override.example.py
@@ -28,7 +28,12 @@ COMPANY_PD_FIELD_MAP = {
     'gclid_expiry_dt': '21685501a4a4fc347f609adcafc9908d774034f9',  # GCLID Expiry Date
     'email_confirmed_dt': '35d6e7ef145f1966d2a53fe7c02c87efd1455587',  # Email Confirmed Date
     'card_saved_dt': '90af5597493bd9a2a0637df22fb29038cbb2a2db',  # Card Saved Date
-    'receive_marketing_emails': 'TODO_PD_FIELD_ID_receive_marketing_emails',  # Receive Marketing Emails (Yes/No)
+    'receive_marketing_emails': 'TODO_PD_FIELD_ID_receive_marketing_emails',  # Single option: Yes / No
+}
+
+# Enum option IDs for single-option fields (from Pipedrive organizationFields API)
+COMPANY_PD_ENUM_OPTION_MAP = {
+    'receive_marketing_emails': {'yes': None, 'no': None},
 }
 
 DEAL_PD_FIELD_MAP = {

--- a/field_mappings_override.example.py
+++ b/field_mappings_override.example.py
@@ -28,6 +28,7 @@ COMPANY_PD_FIELD_MAP = {
     'gclid_expiry_dt': '21685501a4a4fc347f609adcafc9908d774034f9',  # GCLID Expiry Date
     'email_confirmed_dt': '35d6e7ef145f1966d2a53fe7c02c87efd1455587',  # Email Confirmed Date
     'card_saved_dt': '90af5597493bd9a2a0637df22fb29038cbb2a2db',  # Card Saved Date
+    'receive_marketing_emails': 'TODO_PD_FIELD_ID_receive_marketing_emails',  # Receive Marketing Emails (Yes/No)
 }
 
 DEAL_PD_FIELD_MAP = {

--- a/migrations/versions/202606241600_f9cca43b65ba.py
+++ b/migrations/versions/202606241600_f9cca43b65ba.py
@@ -1,0 +1,31 @@
+"""Add receive_marketing_emails to company
+
+Revision ID: f9cca43b65ba
+Revises: e4e0a0696f1f
+Create Date: 2026-06-24 16:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f9cca43b65ba'
+down_revision: Union[str, Sequence[str], None] = 'e4e0a0696f1f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        'company',
+        sa.Column('receive_marketing_emails', sa.Boolean(), nullable=False, server_default=sa.text('false')),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('company', 'receive_marketing_emails')

--- a/tests/callbooker/test_callbooker_booking.py
+++ b/tests/callbooker/test_callbooker_booking.py
@@ -20,7 +20,7 @@ CB_MEETING_DATA = {
     'estimated_income': 1000,
     'currency': 'GBP',
     'price_plan': Company.PP_PAYG,
-    'meeting_dt': datetime(2026, 7, 3, 9, tzinfo=utc).isoformat(),
+    'meeting_dt': datetime(2030, 7, 3, 9, tzinfo=utc).isoformat(),
 }
 
 
@@ -122,7 +122,7 @@ class TestSalesCallBooking:
             Contact(first_name='Brain', last_name='Junes', email='brain@junes.com', company_id=company.id)
         )
 
-        meeting_time = datetime(2026, 7, 3, 9, tzinfo=utc)
+        meeting_time = datetime(2030, 7, 3, 9, tzinfo=utc)
         db.create(
             Meeting(
                 contact_id=contact.id,
@@ -154,7 +154,7 @@ class TestSalesCallBooking:
             Contact(first_name='Brain', last_name='Junes', email='brain@junes.com', company_id=company.id)
         )
 
-        existing_meeting_time = datetime(2026, 7, 3, 11, 0, tzinfo=utc)  # 11:00
+        existing_meeting_time = datetime(2030, 7, 3, 11, 0, tzinfo=utc)  # 11:00
         db.create(
             Meeting(
                 contact_id=contact.id,
@@ -168,7 +168,7 @@ class TestSalesCallBooking:
 
         # Try to book exactly 2 hours before (9:00, buffer window is 9:00-13:00)
         meeting_data = CB_MEETING_DATA.copy()
-        meeting_data['meeting_dt'] = datetime(2026, 7, 3, 9, 0, tzinfo=utc).isoformat()
+        meeting_data['meeting_dt'] = datetime(2030, 7, 3, 9, 0, tzinfo=utc).isoformat()
 
         r = client.post(client.app.url_path_for('book-sales-call'), json={'admin_id': sales_person.id, **meeting_data})
 
@@ -189,7 +189,7 @@ class TestSalesCallBooking:
             Contact(first_name='Brain', last_name='Junes', email='brain@junes.com', company_id=company.id)
         )
 
-        existing_meeting_time = datetime(2026, 7, 3, 13, 1, tzinfo=utc)  # 13:01
+        existing_meeting_time = datetime(2030, 7, 3, 13, 1, tzinfo=utc)  # 13:01
         db.create(
             Meeting(
                 contact_id=contact.id,
@@ -203,7 +203,7 @@ class TestSalesCallBooking:
 
         # Try to book at 9:00 (4+ hours before)
         meeting_data = CB_MEETING_DATA.copy()
-        meeting_data['meeting_dt'] = datetime(2026, 7, 3, 9, 0, tzinfo=utc).isoformat()
+        meeting_data['meeting_dt'] = datetime(2030, 7, 3, 9, 0, tzinfo=utc).isoformat()
 
         r = client.post(client.app.url_path_for('book-sales-call'), json={'admin_id': sales_person.id, **meeting_data})
 
@@ -935,7 +935,7 @@ class TestCallbookerValidation:
     ):
         """Test that admin busy check via Google Calendar freebusy API prevents booking"""
         # Mock admin as busy at the requested time
-        requested_time = datetime(2026, 7, 3, 10, 0, tzinfo=utc)
+        requested_time = datetime(2030, 7, 3, 10, 0, tzinfo=utc)
         mock_gcal_builder.side_effect = fake_gcal_builder(start_dt=requested_time, meeting_dur_mins=30)
 
         admin = db.create(Admin(first_name='Test', last_name='Admin', username='climan@example.com'))
@@ -1006,8 +1006,8 @@ class TestCallbookerValidation:
                 self.body = body
 
             def execute(self):
-                busy_start = datetime(2026, 7, 3, 10, 0, tzinfo=utc)
-                busy_end = datetime(2026, 7, 3, 11, 0, tzinfo=utc)
+                busy_start = datetime(2030, 7, 3, 10, 0, tzinfo=utc)
+                busy_end = datetime(2030, 7, 3, 11, 0, tzinfo=utc)
                 return {
                     'calendars': {
                         admin.username: {
@@ -1038,7 +1038,7 @@ class TestCallbookerValidation:
         mock_resource.events.return_value.insert.side_effect = MockEventInsert
 
         # Test 1: Attempt to book during busy time (10:00-10:30) - should fail
-        busy_time = datetime(2026, 7, 3, 10, 15, tzinfo=utc)
+        busy_time = datetime(2030, 7, 3, 10, 15, tzinfo=utc)
         meeting_data_busy = {
             'admin_id': admin.id,
             'name': 'John Smith',
@@ -1069,7 +1069,7 @@ class TestCallbookerValidation:
         assert len(event_creations) == 0
 
         # Test 2: Book during free time (14:00-14:30) - should succeed
-        free_time = datetime(2026, 7, 3, 14, 0, tzinfo=utc)
+        free_time = datetime(2030, 7, 3, 14, 0, tzinfo=utc)
         meeting_data_free = {
             'admin_id': admin.id,
             'name': 'Jane Doe',

--- a/tests/pipedrive/test_tasks.py
+++ b/tests/pipedrive/test_tasks.py
@@ -530,7 +530,7 @@ class TestSyncDeal:
             'estimated_income': 1000,
             'currency': 'GBP',
             'price_plan': 'payg',
-            'meeting_dt': datetime(2026, 7, 3, 9, tzinfo=utc).isoformat(),
+            'meeting_dt': datetime(2030, 7, 3, 9, tzinfo=utc).isoformat(),
         }
 
         r = client.post(client.app.url_path_for('book-sales-call'), json=meeting_data)
@@ -623,7 +623,7 @@ class TestSyncDeal:
             'estimated_income': 1000,
             'currency': 'GBP',
             'price_plan': 'payg',
-            'meeting_dt': datetime(2026, 7, 3, 9, tzinfo=utc).isoformat(),
+            'meeting_dt': datetime(2030, 7, 3, 9, tzinfo=utc).isoformat(),
         }
 
         r = client.post(client.app.url_path_for('book-sales-call'), json=meeting_data)
@@ -1009,7 +1009,7 @@ class TestSyncMeetingToPipedrive:
             'estimated_income': 1000,
             'currency': 'GBP',
             'price_plan': 'payg',
-            'meeting_dt': datetime(2026, 7, 3, 9, tzinfo=utc).isoformat(),
+            'meeting_dt': datetime(2030, 7, 3, 9, tzinfo=utc).isoformat(),
         }
 
         r = client.post(client.app.url_path_for('book-sales-call'), json=meeting_data)
@@ -1037,7 +1037,7 @@ class TestSyncMeetingToPipedrive:
             'company_id': test_company.id,
             'name': 'Test Person',
             'email': 'test@example.com',
-            'meeting_dt': datetime(2026, 7, 3, 9, tzinfo=utc).isoformat(),
+            'meeting_dt': datetime(2030, 7, 3, 9, tzinfo=utc).isoformat(),
         }
 
         r = client.post(client.app.url_path_for('book-support-call'), json=meeting_data)

--- a/tests/pipedrive/test_tasks.py
+++ b/tests/pipedrive/test_tasks.py
@@ -224,15 +224,22 @@ class TestSyncOrganization:
         db.refresh(test_company)
         assert test_company.pd_org_id == 888
 
-    async def test_company_to_org_data_sends_receive_marketing_emails_as_yes_no(self, db, test_company):
-        """receive_marketing_emails syncs to Pipedrive as Yes/No text (Pipedrive has no boolean field type)."""
+    async def test_company_to_org_data_sends_receive_marketing_emails_as_enum_option_ids(self, db, test_company, monkeypatch):
+        """receive_marketing_emails syncs to Pipedrive as enum option IDs (single-option field)."""
+        from app.pipedrive import field_mappings
+
+        monkeypatch.setitem(
+            field_mappings.COMPANY_PD_ENUM_OPTION_MAP,
+            'receive_marketing_emails',
+            {'yes': 101, 'no': 102},
+        )
         pd_field = COMPANY_PD_FIELD_MAP['receive_marketing_emails']
 
         test_company.receive_marketing_emails = True
-        assert _company_to_org_data(test_company)['custom_fields'][pd_field] == 'Yes'
+        assert _company_to_org_data(test_company)['custom_fields'][pd_field] == 101
 
         test_company.receive_marketing_emails = False
-        assert _company_to_org_data(test_company)['custom_fields'][pd_field] == 'No'
+        assert _company_to_org_data(test_company)['custom_fields'][pd_field] == 102
 
     @patch('app.pipedrive.tasks.get_session')
     @patch('app.pipedrive.tasks.api.update_organisation', new_callable=AsyncMock)

--- a/tests/pipedrive/test_tasks.py
+++ b/tests/pipedrive/test_tasks.py
@@ -224,20 +224,15 @@ class TestSyncOrganization:
         db.refresh(test_company)
         assert test_company.pd_org_id == 888
 
-    async def test_company_to_org_data_skips_unprovisioned_marketing_field(self, db, test_company):
-        """A field whose Pipedrive id is still a TODO_ placeholder is not sent (avoids a Pipedrive 400)."""
-        test_company.receive_marketing_emails = True
-        custom_fields = _company_to_org_data(test_company)['custom_fields']
-        assert COMPANY_PD_FIELD_MAP['receive_marketing_emails'] not in custom_fields
-
-    @patch.dict('app.pipedrive.tasks.COMPANY_PD_FIELD_MAP', {'receive_marketing_emails': 'pd_marketing_field_key'})
     async def test_company_to_org_data_sends_receive_marketing_emails_as_yes_no(self, db, test_company):
-        """Once the Pipedrive field id is provisioned, receive_marketing_emails syncs as Yes/No text."""
+        """receive_marketing_emails syncs to Pipedrive as Yes/No text (Pipedrive has no boolean field type)."""
+        pd_field = COMPANY_PD_FIELD_MAP['receive_marketing_emails']
+
         test_company.receive_marketing_emails = True
-        assert _company_to_org_data(test_company)['custom_fields']['pd_marketing_field_key'] == 'Yes'
+        assert _company_to_org_data(test_company)['custom_fields'][pd_field] == 'Yes'
 
         test_company.receive_marketing_emails = False
-        assert _company_to_org_data(test_company)['custom_fields']['pd_marketing_field_key'] == 'No'
+        assert _company_to_org_data(test_company)['custom_fields'][pd_field] == 'No'
 
     @patch('app.pipedrive.tasks.get_session')
     @patch('app.pipedrive.tasks.api.update_organisation', new_callable=AsyncMock)

--- a/tests/pipedrive/test_tasks.py
+++ b/tests/pipedrive/test_tasks.py
@@ -11,8 +11,9 @@ from sqlalchemy import func
 from sqlmodel import select
 
 from app.main_app.models import Company, Deal
-from app.pipedrive.field_mappings import DEAL_PD_FIELD_MAP
+from app.pipedrive.field_mappings import COMPANY_PD_FIELD_MAP, DEAL_PD_FIELD_MAP
 from app.pipedrive.tasks import (
+    _company_to_org_data,
     _deal_to_pd_data,
     _meeting_to_activity_data,
     partial_sync_deal_from_company,
@@ -222,6 +223,21 @@ class TestSyncOrganization:
         mock_create.assert_called_once()
         db.refresh(test_company)
         assert test_company.pd_org_id == 888
+
+    async def test_company_to_org_data_skips_unprovisioned_marketing_field(self, db, test_company):
+        """A field whose Pipedrive id is still a TODO_ placeholder is not sent (avoids a Pipedrive 400)."""
+        test_company.receive_marketing_emails = True
+        custom_fields = _company_to_org_data(test_company)['custom_fields']
+        assert COMPANY_PD_FIELD_MAP['receive_marketing_emails'] not in custom_fields
+
+    @patch.dict('app.pipedrive.tasks.COMPANY_PD_FIELD_MAP', {'receive_marketing_emails': 'pd_marketing_field_key'})
+    async def test_company_to_org_data_sends_receive_marketing_emails_as_yes_no(self, db, test_company):
+        """Once the Pipedrive field id is provisioned, receive_marketing_emails syncs as Yes/No text."""
+        test_company.receive_marketing_emails = True
+        assert _company_to_org_data(test_company)['custom_fields']['pd_marketing_field_key'] == 'Yes'
+
+        test_company.receive_marketing_emails = False
+        assert _company_to_org_data(test_company)['custom_fields']['pd_marketing_field_key'] == 'No'
 
     @patch('app.pipedrive.tasks.get_session')
     @patch('app.pipedrive.tasks.api.update_organisation', new_callable=AsyncMock)

--- a/tests/pipedrive/test_views.py
+++ b/tests/pipedrive/test_views.py
@@ -36,6 +36,30 @@ class TestPipedriveWebhookEndpoint:
         assert test_company.name == 'Updated Name'
         assert test_company.paid_invoice_count == 15
 
+    async def test_pipedrive_callback_does_not_overwrite_marketing_consent(self, client, db, test_company):
+        """receive_marketing_emails is TC2-authoritative: an inbound Pipedrive org webhook must not change it."""
+        test_company.pd_org_id = 999
+        test_company.receive_marketing_emails = True
+        db.add(test_company)
+        db.commit()
+
+        webhook_data = {
+            'meta': {'entity': 'organization', 'action': 'updated'},
+            'data': {
+                'id': 999,
+                COMPANY_PD_FIELD_MAP['hermes_id']: test_company.id,
+                'name': 'Updated Name',
+                COMPANY_PD_FIELD_MAP['receive_marketing_emails']: 'No',
+            },
+            'previous': {},
+        }
+
+        r = client.post(client.app.url_path_for('pipedrive-callback'), json=webhook_data)
+        assert r.status_code == 200
+
+        db.refresh(test_company)
+        assert test_company.receive_marketing_emails is True
+
     async def test_pipedrive_callback_organization_with_previous(self, client, db, test_company):
         """Test webhook for organization with previous data"""
         test_company.pd_org_id = 999

--- a/tests/tc2/test_tc2_integration.py
+++ b/tests/tc2/test_tc2_integration.py
@@ -2179,7 +2179,7 @@ class TestGetOrCreateDealConsolidation:
                 'estimated_income': 1000,
                 'currency': 'GBP',
                 'price_plan': 'payg',
-                'meeting_dt': '2026-07-03T09:00:00Z',
+                'meeting_dt': '2030-07-03T09:00:00Z',
             },
         )
 
@@ -2317,7 +2317,7 @@ class TestGetOrCreateDealConsolidation:
                 'estimated_income': 1000,
                 'currency': 'GBP',
                 'price_plan': 'payg',
-                'meeting_dt': '2026-07-03T09:00:00Z',
+                'meeting_dt': '2030-07-03T09:00:00Z',
             },
         )
 
@@ -2487,7 +2487,7 @@ class TestGetOrCreateDealConsolidation:
                 'estimated_income': 1000,
                 'currency': 'GBP',
                 'price_plan': 'payg',
-                'meeting_dt': '2026-07-03T09:00:00Z',
+                'meeting_dt': '2030-07-03T09:00:00Z',
             },
         )
 

--- a/tests/tc2/test_tc2_integration.py
+++ b/tests/tc2/test_tc2_integration.py
@@ -35,6 +35,7 @@ def sample_tc_client_data(test_admin):
             'created': '2024-01-01T00:00:00Z',
             'price_plan': 'monthly-payg',
             'narc': False,
+            'receive_marketing_emails': True,
         },
         'user': {'first_name': 'John', 'last_name': 'Doe', 'email': 'john@example.com', 'phone': '+1234567890'},
         'status': 'active',
@@ -67,6 +68,7 @@ class TestTC2Integration:
         assert company.price_plan == 'payg'
         assert company.utm_source == 'google'
         assert company.utm_campaign == 'summer2024'
+        assert company.receive_marketing_emails is True
         assert company.sales_person_id == test_admin.id
 
     async def test_process_tc_client_creates_contacts(self, db, test_admin, sample_tc_client_data):
@@ -100,6 +102,17 @@ class TestTC2Integration:
         assert updated_company.name == original_name  # name is NOT syncable
         assert updated_company.paid_invoice_count == 10  # paid_invoice_count IS syncable
         assert updated_company.price_plan == 'startup'  # price_plan IS syncable
+
+    async def test_process_tc_client_syncs_receive_marketing_emails(self, db, test_admin, sample_tc_client_data):
+        """receive_marketing_emails is syncable: a changed value from TC2 updates the existing company."""
+        company = await process_tc_client(TCClient(**sample_tc_client_data), db)
+        assert company.receive_marketing_emails is True
+
+        sample_tc_client_data['meta_agency']['receive_marketing_emails'] = False
+        updated_company = await process_tc_client(TCClient(**sample_tc_client_data), db)
+
+        assert updated_company.id == company.id
+        assert updated_company.receive_marketing_emails is False
 
     @patch('httpx.AsyncClient.request')
     async def test_tc2_webhook_triggers_pipedrive_sync(


### PR DESCRIPTION
<!-- full-review-stamp -->
> **🤖 Run through `/full-review` — reviewed commit `e708c82` · verdict: APPROVED**
> architect · code-reviewer · security-auditor · performance-reviewer (2026-06-29). All four approved; CI `test` green; 100% patch coverage; `make lint` clean; migration safe.
<!-- /full-review-stamp -->
## What & why

TutorCruncher2 added a **marketing-email consent** flag on the Agency ([tutorcruncher/TutorCruncher2#16773](https://github.com/tutorcruncher/TutorCruncher2/pull/16773)) and now sends `receive_marketing_emails` on the cligency webhook (nested in the `meta_agency` object). This wires that value through Hermes into Pipedrive so marketing can segment on it.

## How it works

`receive_marketing_emails` flows the same way as the other agency fields (`paid_invoice_count`, `tc2_status`, …):

1. **Parse** — added to `_TCAgency` (`app/tc2/models.py`), the model for the inbound `meta_agency` payload.
2. **Store** — new `Company.receive_marketing_emails` boolean column (`app/main_app/models.py`) + Alembic migration.
3. **Keep fresh** — added to `COMPANY_SYNCABLE_FIELDS` so the recurring TC2 sync updates it on existing companies.
4. **Map to Pipedrive** — added to `COMPANY_PD_FIELD_MAP`; it syncs to a Pipedrive **Organization** custom field. Pipedrive has no native boolean type, so it's stored as **`Yes`/`No` text** (bool→`Yes`/`No` on outbound in `_company_to_org_data`).

### Design notes
- **One-way (TC2 is the source of truth for consent).** The field is excluded from `OrganisationProcessor.custom_field_names`, so an inbound Pipedrive edit can never silently flip a company's consent — only TC2 writes it. (This is the first company custom field that is intentionally outbound-only; the others are bidirectional.)
- **Organization, not Person `marketing_status`.** It's an agency-level consent flag, and `marketing_status` (#398) is a write-once per-person field that we must not overwrite on updates — the wrong granularity/lifecycle for a value that can flip in TC2.


## Screenshots
**Before
didn't exists
**After**

<img width="2352" height="323" alt="image" src="https://github.com/user-attachments/assets/14faa132-7cf0-4089-a4eb-4c759c15281e" />
<img width="848" height="85" alt="image" src="https://github.com/user-attachments/assets/487c86d0-f7c7-4c14-b796-ac4250359aff" />


## Tests
- TC2 parse / create / syncable-update of the new field.
- Outbound: the bool serialises as `Yes`/`No` text under the mapped key (the placeholder key must be replaced with the real Pipedrive field id before deploy — see above).
- Inbound: a Pipedrive org webhook does **not** overwrite a TC2-set consent value.
- Full suite green; new lines covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
