### PR TITLE
Export logging and httpx telemetry to Logfire

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -18,6 +18,8 @@ class Settings(BaseSettings):
     log_level: str = 'INFO'
 
     logfire_token: Optional[str] = None
+    # Shown as deployment_environment on all telemetry, e.g. 'production' / 'beta'
+    logfire_environment: Optional[str] = None
 
     # Postgres
     database_url: PostgresDsn = Field(

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+import logging
 from contextlib import asynccontextmanager
 
 import logfire
@@ -16,7 +17,17 @@ logger = get_logger('hermes')
 
 # Initialize Logfire
 if settings.logfire_token:
-    logfire.configure(token=settings.logfire_token)
+    logfire.configure(
+        token=settings.logfire_token,
+        service_name='hermes',
+        environment=settings.logfire_environment,
+    )
+    # Send stdlib logging records to Logfire as well as stdout. Without this every
+    # logger.error (including swallowed webhook processing errors) is only visible
+    # in the rolling Heroku log buffer, not in Logfire.
+    logging.getLogger().addHandler(logfire.LogfireLoggingHandler())
+    # Trace outbound TC2/Pipedrive API calls, including error responses.
+    logfire.instrument_httpx()
 
 # Initialize Sentry
 if settings.sentry_dsn:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     'pydantic==2.12.4',
     'pydantic-settings==2.11.0',
     'python-multipart==0.0.20',
-    'logfire[requests,fastapi]==4.14.2',
+    'logfire[requests,fastapi,httpx]==4.14.2',
     'sentry-sdk==2.43.0',
     'python-dotenv==1.2.1',
     'psycopg2-binary==2.9.11',

--- a/uv.lock
+++ b/uv.lock
@@ -773,7 +773,7 @@ dependencies = [
     { name = "gunicorn" },
     { name = "httpx" },
     { name = "httpx-limiter" },
-    { name = "logfire", extra = ["fastapi", "requests"] },
+    { name = "logfire", extra = ["fastapi", "httpx", "requests"] },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -817,7 +817,7 @@ requires-dist = [
     { name = "gunicorn", specifier = "==23.0.0" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "httpx-limiter", specifier = ">=0.4.0" },
-    { name = "logfire", extras = ["requests", "fastapi"], specifier = "==4.14.2" },
+    { name = "logfire", extras = ["requests", "fastapi", "httpx"], specifier = "==4.14.2" },
     { name = "psycopg2-binary", specifier = "==2.9.11" },
     { name = "pydantic", specifier = "==2.12.4" },
     { name = "pydantic-settings", specifier = "==2.11.0" },
@@ -1055,6 +1055,9 @@ wheels = [
 [package.optional-dependencies]
 fastapi = [
     { name = "opentelemetry-instrumentation-fastapi" },
+]
+httpx = [
+    { name = "opentelemetry-instrumentation-httpx" },
 ]
 requests = [
     { name = "opentelemetry-instrumentation-requests" },
@@ -1395,6 +1398,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/64/09/4f8fcab834af6b403e5e2d94bdfb2d0835ba8cd1049bcc156995f47b65fb/opentelemetry_instrumentation_fastapi-0.58b0.tar.gz", hash = "sha256:03da470d694116a0a40f4e76319e42f3ff9efc49abf804b2acc2c07f96661497", size = 24598, upload-time = "2025-09-11T11:42:35.325Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/fb/82de06eba54e5cb979274f073065ebc374794853502d342b5155073d1194/opentelemetry_instrumentation_fastapi-0.58b0-py3-none-any.whl", hash = "sha256:d89bfec69c9ffc5d9f3fe58655d6660a66b2bca863b9132712c06edcde68b6fa", size = 13460, upload-time = "2025-09-11T11:41:28.507Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-httpx"
+version = "0.58b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/21/ba3a0106795337716e5e324f58fd3c04f5967e330c0408d0d68d873454db/opentelemetry_instrumentation_httpx-0.58b0.tar.gz", hash = "sha256:3cd747e7785a06d06bd58875e8eb11595337c98c4341f4fe176ff1f734a90db7", size = 19887, upload-time = "2025-09-11T11:42:37.926Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/e7/6dc8ee4881889993fa4a7d3da225e5eded239c975b9831eff392abd5a5e4/opentelemetry_instrumentation_httpx-0.58b0-py3-none-any.whl", hash = "sha256:d3f5a36c7fed08c245f1b06d1efd91f624caf2bff679766df80981486daaccdb", size = 15197, upload-time = "2025-09-11T11:41:32.66Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Issue number: #406**

### Technical description of changes

Sends Python logging records to Logfire by attaching `LogfireLoggingHandler` to the root logger, so swallowed webhook errors are no longer stdout-only. Also sets `service_name`/`environment` on `logfire.configure` (records showed `unknown_service`) and instruments httpx to trace outbound TC2/Pipedrive calls, which needs the `logfire[httpx]` extra. The alerting and webhook retry semantics from #406 are not code changes here, so the issue stays open.


Check

* [x] Issue number added
* [x] The original issue clearly outlines the problem solved
* [ ] Tests
* [ ] Coverage
* [ ] Correct labels applied
