### PR TITLE
Carry the company's real utm through the call-booker signup link

### DIFF
--- a/app/callbooker/meeting_templates.py
+++ b/app/callbooker/meeting_templates.py
@@ -17,7 +17,7 @@ This guide should cover most initial questions:
 <a href="https://cdn.tutorcruncher.com/guides/admin-user-guide.pdf" target="_blank">Admin user guide.</a>
 
 If you haven't signed up yet, \
-<a href="https://secure.tutorcruncher.com/start/1/?cli_id={tc2_cligency_id}&tc_source=call_booker">click here to start \
+<a href="https://secure.tutorcruncher.com/start/1/?cli_id={tc2_cligency_id}&{signup_tracking_params}">click here to start \
 your two week free trial now</a>. You won't have to enter any payment details, and we find our demo is most effective \
 when you have had a chance to play around with the system first.
 
@@ -49,7 +49,7 @@ This guide should cover most initial questions:
 <a href="https://cdn.tutorcruncher.com/guides/admin-user-guide.pdf" target="_blank">Admin user guide.</a>
 
 If you haven't signed up yet, \
-<a href="https://secure.tutorcruncher.com/start/1/?cli_id={tc2_cligency_id}&tc_source=call_booker" target="_blank">\
+<a href="https://secure.tutorcruncher.com/start/1/?cli_id={tc2_cligency_id}&{signup_tracking_params}" target="_blank">\
 click here to start your two week free trial now</a>. You won't have to enter any payment details, and we find our \
 demo is most effective when you have had a chance to play around with the system first.
 

--- a/app/callbooker/process.py
+++ b/app/callbooker/process.py
@@ -221,9 +221,11 @@ def _delete_meeting_on_calendar_failure(meeting_id: int, db: DBSession) -> None:
 
 def _build_meeting_template_vars(company: Company, contact: Contact, admin: Admin, meeting_type: str) -> dict:
     """Build template variables for meeting description"""
-    # The signup link carries the company's real acquisition source (captured when
-    # the call was booked) so signing up via this email doesn't overwrite it;
-    # 'call_booker' is only a fallback when we never captured one.
+    # The signup link carries the company's recorded acquisition source so that signing up from
+    # this email doesn't overwrite it with 'call_booker'. That is whatever source was first
+    # captured for the company - get_or_create_contact_company only applies the booking payload's
+    # utm when it creates the company, so a repeat booking does not update it.
+    # 'call_booker' is only a fallback when no source was ever captured.
     tracking_params = {'tc_source': company.utm_source or 'call_booker'}
     if company.utm_campaign:
         tracking_params['tc_campaign'] = company.utm_campaign

--- a/app/callbooker/process.py
+++ b/app/callbooker/process.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
 
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
@@ -220,12 +221,19 @@ def _delete_meeting_on_calendar_failure(meeting_id: int, db: DBSession) -> None:
 
 def _build_meeting_template_vars(company: Company, contact: Contact, admin: Admin, meeting_type: str) -> dict:
     """Build template variables for meeting description"""
+    # The signup link carries the company's real acquisition source (captured when
+    # the call was booked) so signing up via this email doesn't overwrite it;
+    # 'call_booker' is only a fallback when we never captured one.
+    tracking_params = {'tc_source': company.utm_source or 'call_booker'}
+    if company.utm_campaign:
+        tracking_params['tc_campaign'] = company.utm_campaign
     template_vars = {
         'contact_first_name': contact.first_name or 'there',
         'company_name': company.name,
         'admin_name': admin.first_name,
         'tc2_cligency_id': company.tc2_cligency_id or '',
         'tc2_cligency_url': company.tc2_cligency_url or '',
+        'signup_tracking_params': urlencode(tracking_params),
     }
 
     if meeting_type == Meeting.TYPE_SALES:

--- a/tests/callbooker/test_callbooker_booking.py
+++ b/tests/callbooker/test_callbooker_booking.py
@@ -24,6 +24,23 @@ CB_MEETING_DATA = {
 }
 
 
+def capturing_gcal_builder(captured_events: list, admin_email: str = 'climan@example.com'):
+    """
+    Mock Google Calendar resource builder that records the body of every event it inserts.
+
+    Lets a test assert on the description actually handed to the Google Calendar API, so template
+    placeholders that no longer match the template vars fail here rather than in production.
+    """
+    base_resource = fake_gcal_builder(admin_email=admin_email)
+
+    class CapturingGCalResource(base_resource):
+        def insert(self, *args, **kwargs):
+            captured_events.append(kwargs['body'])
+            return self
+
+    return CapturingGCalResource
+
+
 def get_pipedrive_call_data(mock_pipedrive, endpoint: str, method: str):
     """Extract data from a specific Pipedrive API call"""
     calls = [
@@ -676,6 +693,94 @@ class TestSupportCallBooking:
 
         assert r.status_code == 400
         assert r.json()['status'] == 'error'
+
+
+class TestSignupLinkAttribution:
+    """Test the signup link in the calendar invite carries the company's acquisition source"""
+
+    @patch('fastapi.BackgroundTasks.add_task')
+    @patch('app.callbooker.google.AdminGoogleCalendar._create_resource')
+    async def test_sales_call_invite_carries_the_booking_utm(
+        self, mock_gcal_builder, mock_add_task, client, db, test_pipeline, test_stage, test_config
+    ):
+        """Test utm in the sales booking payload reaches the signup link in the calendar invite"""
+        captured_events = []
+        mock_gcal_builder.side_effect = capturing_gcal_builder(captured_events)
+        sales_person = db.create(Admin(first_name='Steve', last_name='Jobs', username='climan@example.com'))
+
+        meeting_data = CB_MEETING_DATA.copy()
+        meeting_data['utm_source'] = 'google.com'
+        meeting_data['utm_campaign'] = 'tc-home-US'
+
+        r = client.post(client.app.url_path_for('book-sales-call'), json={'admin_id': sales_person.id, **meeting_data})
+
+        assert r.status_code == 200, r.json()
+
+        company = db.exec(select(Company)).one()
+        assert company.utm_source == 'google.com'
+        assert company.utm_campaign == 'tc-home-US'
+
+        description = captured_events[0]['description']
+        assert '/start/1/?cli_id=&tc_source=google.com&tc_campaign=tc-home-US"' in description
+
+    @patch('fastapi.BackgroundTasks.add_task')
+    @patch('app.callbooker.google.AdminGoogleCalendar._create_resource')
+    async def test_support_call_invite_carries_the_stored_utm(
+        self, mock_gcal_builder, mock_add_task, client, db, test_pipeline, test_stage, test_config
+    ):
+        """Test a support invite carries the company's stored utm_source, not call_booker"""
+        captured_events = []
+        mock_gcal_builder.side_effect = capturing_gcal_builder(captured_events, admin_email='support@example.com')
+        admin = db.create(Admin(first_name='Support', last_name='Person', username='support@example.com'))
+        company = db.create(
+            Company(
+                name='Junes Ltd',
+                sales_person_id=admin.id,
+                price_plan='payg',
+                country='GB',
+                tc2_cligency_id=10,
+                utm_source='bing.com',
+            )
+        )
+
+        meeting_data = CB_MEETING_DATA.copy()
+        meeting_data['company_id'] = company.id
+
+        r = client.post(client.app.url_path_for('book-support-call'), json={'admin_id': admin.id, **meeting_data})
+
+        assert r.status_code == 200, r.json()
+
+        description = captured_events[0]['description']
+        assert '/start/1/?cli_id=10&tc_source=bing.com"' in description
+
+    @patch('fastapi.BackgroundTasks.add_task')
+    @patch('app.callbooker.google.AdminGoogleCalendar._create_resource')
+    async def test_invite_falls_back_to_call_booker_without_utm(
+        self, mock_gcal_builder, mock_add_task, client, db, test_pipeline, test_stage, test_config
+    ):
+        """Test the signup link falls back to call_booker when the company has no captured utm"""
+        captured_events = []
+        mock_gcal_builder.side_effect = capturing_gcal_builder(captured_events, admin_email='support@example.com')
+        admin = db.create(Admin(first_name='Support', last_name='Person', username='support@example.com'))
+        company = db.create(
+            Company(
+                name='Junes Ltd',
+                sales_person_id=admin.id,
+                price_plan='payg',
+                country='GB',
+                tc2_cligency_id=10,
+            )
+        )
+
+        meeting_data = CB_MEETING_DATA.copy()
+        meeting_data['company_id'] = company.id
+
+        r = client.post(client.app.url_path_for('book-support-call'), json={'admin_id': admin.id, **meeting_data})
+
+        assert r.status_code == 200, r.json()
+
+        description = captured_events[0]['description']
+        assert '/start/1/?cli_id=10&tc_source=call_booker"' in description
 
 
 class TestCallbookerValidation:

--- a/tests/callbooker/test_process_coverage.py
+++ b/tests/callbooker/test_process_coverage.py
@@ -12,6 +12,7 @@ from app.callbooker.meeting_templates import MEETING_CONTENT_TEMPLATES
 from app.callbooker.models import CBSalesCall
 from app.callbooker.process import _build_meeting_template_vars, book_meeting
 from app.main_app.models import Config, Deal, Meeting, Pipeline, Stage
+from tests.factories import CompanyFactory
 from tests.helpers import fake_gcal_builder
 
 
@@ -375,16 +376,41 @@ class TestAvailabilityEndpoint:
 
 
 class TestMeetingTemplateVars:
-    def test_signup_link_uses_company_utm(self, test_admin, test_company, test_contact):
-        test_company.utm_source = 'google'
-        test_company.utm_campaign = 'US Search'
-        template_vars = _build_meeting_template_vars(test_company, test_contact, test_admin, Meeting.TYPE_SUPPORT)
+    """Test the signup link in the meeting description carries the company's utm"""
+
+    def test_signup_link_uses_company_utm(self, db, test_admin, test_contact):
+        """Test the signup link carries the company's utm_source and utm_campaign"""
+        company = CompanyFactory.create_with_db(
+            db, sales_person_id=test_admin.id, tc2_cligency_id=10, utm_source='google', utm_campaign='US Search'
+        )
+        template_vars = _build_meeting_template_vars(company, test_contact, test_admin, Meeting.TYPE_SUPPORT)
         assert template_vars['signup_tracking_params'] == 'tc_source=google&tc_campaign=US+Search'
         description = MEETING_CONTENT_TEMPLATES['support'].format(**template_vars)
-        assert f'/start/1/?cli_id={test_company.tc2_cligency_id or ""}&tc_source=google&tc_campaign=US+Search' in description
+        assert '/start/1/?cli_id=10&tc_source=google&tc_campaign=US+Search' in description
+
+    def test_signup_link_omits_campaign_when_only_source_is_set(self, db, test_admin, test_contact):
+        """Test the signup link carries tc_source alone when the company has no utm_campaign"""
+        company = CompanyFactory.create_with_db(
+            db, sales_person_id=test_admin.id, tc2_cligency_id=10, utm_source='google'
+        )
+        template_vars = _build_meeting_template_vars(company, test_contact, test_admin, Meeting.TYPE_SUPPORT)
+        assert template_vars['signup_tracking_params'] == 'tc_source=google'
+        description = MEETING_CONTENT_TEMPLATES['support'].format(**template_vars)
+        assert '/start/1/?cli_id=10&tc_source=google">' in description
+
+    def test_signup_link_escapes_hostile_utm_source(self, db, test_admin, test_contact):
+        """Test a utm_source from the public booking endpoint cannot break out of the href"""
+        company = CompanyFactory.create_with_db(
+            db, sales_person_id=test_admin.id, tc2_cligency_id=10, utm_source='a&b="x"<script>'
+        )
+        template_vars = _build_meeting_template_vars(company, test_contact, test_admin, Meeting.TYPE_SUPPORT)
+        assert template_vars['signup_tracking_params'] == 'tc_source=a%26b%3D%22x%22%3Cscript%3E'
+        description = MEETING_CONTENT_TEMPLATES['support'].format(**template_vars)
+        assert '/start/1/?cli_id=10&tc_source=a%26b%3D%22x%22%3Cscript%3E">' in description
 
     def test_signup_link_falls_back_to_call_booker(self, test_admin, test_company, test_contact):
+        """Test the signup link falls back to call_booker when no utm was ever captured"""
         template_vars = _build_meeting_template_vars(test_company, test_contact, test_admin, Meeting.TYPE_SALES)
         assert template_vars['signup_tracking_params'] == 'tc_source=call_booker'
         description = MEETING_CONTENT_TEMPLATES['sales'].format(**template_vars)
-        assert 'tc_source=call_booker' in description
+        assert '/start/1/?cli_id=&tc_source=call_booker"' in description

--- a/tests/callbooker/test_process_coverage.py
+++ b/tests/callbooker/test_process_coverage.py
@@ -8,9 +8,10 @@ from unittest.mock import AsyncMock, patch
 from pytz import utc
 from sqlmodel import select
 
+from app.callbooker.meeting_templates import MEETING_CONTENT_TEMPLATES
 from app.callbooker.models import CBSalesCall
-from app.callbooker.process import book_meeting
-from app.main_app.models import Config, Deal, Pipeline, Stage
+from app.callbooker.process import _build_meeting_template_vars, book_meeting
+from app.main_app.models import Config, Deal, Meeting, Pipeline, Stage
 from tests.helpers import fake_gcal_builder
 
 
@@ -371,3 +372,19 @@ class TestAvailabilityEndpoint:
         assert data['status'] == 'ok'
         # Should have some slots but not at 10:00-11:00
         assert isinstance(data['slots'], list)
+
+
+class TestMeetingTemplateVars:
+    def test_signup_link_uses_company_utm(self, test_admin, test_company, test_contact):
+        test_company.utm_source = 'google'
+        test_company.utm_campaign = 'US Search'
+        template_vars = _build_meeting_template_vars(test_company, test_contact, test_admin, Meeting.TYPE_SUPPORT)
+        assert template_vars['signup_tracking_params'] == 'tc_source=google&tc_campaign=US+Search'
+        description = MEETING_CONTENT_TEMPLATES['support'].format(**template_vars)
+        assert f'/start/1/?cli_id={test_company.tc2_cligency_id or ""}&tc_source=google&tc_campaign=US+Search' in description
+
+    def test_signup_link_falls_back_to_call_booker(self, test_admin, test_company, test_contact):
+        template_vars = _build_meeting_template_vars(test_company, test_contact, test_admin, Meeting.TYPE_SALES)
+        assert template_vars['signup_tracking_params'] == 'tc_source=call_booker'
+        description = MEETING_CONTENT_TEMPLATES['sales'].format(**template_vars)
+        assert 'tc_source=call_booker' in description


### PR DESCRIPTION
## Summary
The meeting-confirmation email linked to `/start/` with a hardcoded `tc_source=call_booker`, overwriting the acquisition source hermes had already captured when the call was booked. This is where all the `utm_source=call_booker` companies in BigQuery come from.

## What we did
- The signup link now passes the company's captured `utm_source`/`utm_campaign` (urlencoded), falling back to `call_booker` only when none was captured.
- Added tests for both cases; full suite passes (305).

Related: tutorcruncher/tutorcruncher-website#106, tutorcruncher/tutorcruncher-website#107, tutorcruncher/TutorCruncher2#17398

🤖 Generated with [Claude Code](https://claude.com/claude-code)